### PR TITLE
Document RDKit installation and make dependency optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Diffusion Assembly
+
+Prototype package for molecular assembly diffusion.
+
+## Installation
+
+Create and activate a virtual environment, then install the package requirements:
+
+```bash
+pip install torch
+pip install -e .
+```
+
+### RDKit
+
+RDKit is an optional dependency used for molecule manipulation and loading the QM9 dataset. It is often easier to install via conda:
+
+```bash
+conda install -c conda-forge rdkit
+```
+
+Without RDKit, features such as canonical SMILES generation and QM9 dataset loading will be unavailable and will raise informative errors.
+
+## Testing
+
+Run the test suite (if present) with:
+
+```bash
+pytest
+```
+

--- a/assembly_diffusion/data.py
+++ b/assembly_diffusion/data.py
@@ -24,8 +24,13 @@ def download_qm9():
 
 def load_qm9_chon(max_heavy: int = 12):
     """Load molecules from the QM9 dataset restricted to C/H/O/N."""
-    from rdkit.Chem import rdmolfiles
     import torch
+    try:
+        from rdkit.Chem import rdmolfiles
+    except ImportError as e:  # pragma: no cover - runtime check
+        raise ImportError(
+            "RDKit is required to load QM9 data. Install it, e.g., via 'conda install -c conda-forge rdkit'."
+        ) from e
 
     if not os.path.exists("qm9_raw/gdb9.sdf"):
         download_qm9()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 torch
-rdkit-pypi
+# RDKit is optional and often easier to install via conda:
+# conda install -c conda-forge rdkit


### PR DESCRIPTION
## Summary
- document installation and optional RDKit dependency
- handle missing RDKit gracefully in molecule utilities and dataset loader
- mark RDKit as optional in requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689047c754a08325bf265d2d04b9be30