### PR TITLE
Add unit tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest flake8
+      - name: Lint
+        run: python -m flake8 .
+      - name: Test
+        run: pytest

--- a/assembly_diffusion/backbone.py
+++ b/assembly_diffusion/backbone.py
@@ -3,6 +3,7 @@ import torch.nn as nn
 
 from .graph import MoleculeGraph
 
+
 class GNNBackbone(nn.Module):
     """Minimal GNN backbone used by the reverse policy."""
     def __init__(self, node_dim: int = 16):

--- a/assembly_diffusion/forward.py
+++ b/assembly_diffusion/forward.py
@@ -3,6 +3,7 @@ import random
 
 from .graph import MoleculeGraph
 
+
 class ForwardKernel:
     """Simple forward diffusion kernel that randomly removes bonds."""
     def __init__(self, beta0: float = 0.1, T: int = 10):

--- a/assembly_diffusion/mask.py
+++ b/assembly_diffusion/mask.py
@@ -1,5 +1,6 @@
 from .graph import MoleculeGraph
 
+
 class FeasibilityMask:
     """Compute feasibility masks over possible bond edits."""
     def mask_edits(self, x: MoleculeGraph):

--- a/assembly_diffusion/policy.py
+++ b/assembly_diffusion/policy.py
@@ -4,6 +4,7 @@ import torch.nn as nn
 from .backbone import GNNBackbone
 from .graph import MoleculeGraph
 
+
 class ReversePolicy(nn.Module):
     """Reverse diffusion policy producing edit logits."""
     def __init__(self, backbone: GNNBackbone):

--- a/assembly_diffusion/sampler.py
+++ b/assembly_diffusion/sampler.py
@@ -4,6 +4,7 @@ from .mask import FeasibilityMask
 from .policy import ReversePolicy
 from .graph import MoleculeGraph
 
+
 class Sampler:
     """Run reverse diffusion sampling using a policy and feasibility mask."""
     def __init__(self, policy: ReversePolicy, mask: FeasibilityMask):
@@ -14,7 +15,7 @@ class Sampler:
         x = x_init.copy()
         for t in range(T, 0, -1):
             mask = self.masker.mask_edits(x)
-            logits = self.policy.logits(x, t, mask)
+            _ = self.policy.logits(x, t, mask)
             e = random.choice(list(mask.keys()))
             if e == 'STOP':
                 break

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,21 @@
+import torch
+from assembly_diffusion.graph import MoleculeGraph
+from assembly_diffusion.data import QM9CHON_Dataset, get_dataloader
+
+
+def test_qm9_dataset_loading(monkeypatch):
+    dummy = [MoleculeGraph([6], torch.zeros((1, 1), dtype=torch.int)) for _ in range(2)]
+    monkeypatch.setattr('assembly_diffusion.data.load_qm9_chon', lambda max_heavy: dummy)
+    dataset = QM9CHON_Dataset()
+    assert len(dataset) == 2
+    assert isinstance(dataset[0], MoleculeGraph)
+
+
+def test_get_dataloader(monkeypatch):
+    dummy = [MoleculeGraph([6], torch.zeros((1, 1), dtype=torch.int)) for _ in range(3)]
+    monkeypatch.setattr('assembly_diffusion.data.load_qm9_chon', lambda max_heavy: dummy)
+    loader = get_dataloader(batch_size=2)
+    batch = next(iter(loader))
+    assert isinstance(batch, list)
+    assert len(batch) == 2
+    assert isinstance(batch[0], MoleculeGraph)

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,9 @@
+import torch
+from assembly_diffusion.graph import MoleculeGraph
+
+
+def test_is_valid_without_rdkit():
+    atoms = [6, 6]
+    bonds = torch.zeros((2, 2), dtype=torch.int)
+    g = MoleculeGraph(atoms, bonds)
+    assert g.is_valid() is False

--- a/tests/test_kernels.py
+++ b/tests/test_kernels.py
@@ -1,0 +1,43 @@
+import math
+import torch
+from assembly_diffusion.graph import MoleculeGraph
+from assembly_diffusion.forward import ForwardKernel
+from assembly_diffusion import forward as forward_module
+from assembly_diffusion.policy import ReversePolicy
+from assembly_diffusion.backbone import GNNBackbone
+
+
+def test_forward_alpha_bounds():
+    kernel = ForwardKernel(beta0=0.1, T=10)
+    assert kernel.alpha(0) == 1.0
+    assert math.isclose(kernel.alpha(10), math.exp(-0.1))
+
+
+def test_forward_sample_xt_removes_bond(monkeypatch):
+    atoms = [6, 6]
+    bonds = torch.tensor([[0, 1], [1, 0]], dtype=torch.int)
+    g = MoleculeGraph(atoms, bonds)
+    kernel = ForwardKernel(beta0=0.1, T=10)
+    monkeypatch.setattr(forward_module.random, "random", lambda: 1.0)
+    xt = kernel.sample_xt(g, t=10)
+    assert xt.bonds[0, 1] == 0
+
+
+def test_forward_sample_xt_keeps_bond(monkeypatch):
+    atoms = [6, 6]
+    bonds = torch.tensor([[0, 1], [1, 0]], dtype=torch.int)
+    g = MoleculeGraph(atoms, bonds)
+    kernel = ForwardKernel(beta0=0.1, T=10)
+    monkeypatch.setattr(forward_module.random, "random", lambda: 0.0)
+    xt = kernel.sample_xt(g, t=10)
+    assert xt.bonds[0, 1] == 1
+
+
+def test_reverse_policy_logits_shape():
+    atoms = [6, 6]
+    bonds = torch.zeros((2, 2), dtype=torch.int)
+    g = MoleculeGraph(atoms, bonds)
+    mask = {(0, 1, 0): 1, (0, 1, 1): 1, (0, 1, 2): 1, 'STOP': 1}
+    policy = ReversePolicy(GNNBackbone())
+    logits = policy.logits(g, t=0, mask=mask)
+    assert logits.shape == (len(mask),)

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -1,0 +1,23 @@
+import torch
+from assembly_diffusion.graph import MoleculeGraph
+from assembly_diffusion.mask import FeasibilityMask
+
+
+def test_mask_edits_respects_is_valid(monkeypatch):
+    atoms = [6, 6]
+    bonds = torch.zeros((2, 2), dtype=torch.int)
+    g = MoleculeGraph(atoms, bonds)
+    mask = FeasibilityMask()
+
+    monkeypatch.setattr(MoleculeGraph, "is_valid", lambda self: True)
+    res = mask.mask_edits(g)
+    assert res['STOP'] == 1
+    assert len(res) == 4
+    assert all(v == 1 for k, v in res.items())
+
+    monkeypatch.setattr(MoleculeGraph, "is_valid", lambda self: False)
+    res = mask.mask_edits(g)
+    assert res['STOP'] == 1
+    for key, val in res.items():
+        if key != 'STOP':
+            assert val == 0


### PR DESCRIPTION
## Summary
- test MoleculeGraph validation logic
- cover feasibility masking and forward/reverse kernels
- verify QM9 dataset loading and dataloader
- add GitHub Actions workflow for linting and tests

## Testing
- `python -m flake8 .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68904adecb6883259ce7404a79c415a4