### PR TITLE
feat: improve QM9 dataset handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ conda install -c conda-forge rdkit
 
 Without RDKit, features such as canonical SMILES generation and QM9 dataset loading will be unavailable and will raise informative errors.
 
+### Dataset Handling
+
+The QM9 dataset is downloaded on demand. By default files are stored in a
+`qm9_raw` directory, but the location can be overridden by setting the
+`QM9_DATA_DIR` environment variable. Downloads are verified against a
+SHA-256 checksum and corrupted archives trigger a clear error so they can be
+re-downloaded.
+
 ## Testing
 
 Run the test suite (if present) with:

--- a/assembly_diffusion/data.py
+++ b/assembly_diffusion/data.py
@@ -1,30 +1,81 @@
+import hashlib
 import os
-import urllib.request
 import tarfile
+import urllib.request
 
-from torch.utils.data import Dataset, DataLoader
+from torch.utils.data import DataLoader, Dataset
 
 from .graph import MoleculeGraph
 
 URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/gdb9.tar.gz"
+QM9_SHA256 = "45255048ac6d83ea4b923ecdf7d6fb6dc62bfec5e80fbc5bcfd93a62157a31db"
+DEFAULT_DATA_DIR = os.environ.get("QM9_DATA_DIR", "qm9_raw")
 
 
-def download_qm9():
-    """Download and extract the QM9 dataset if necessary."""
-    os.makedirs("qm9_raw", exist_ok=True)
-    archive_path = "qm9_raw/gdb9.tar.gz"
-    if not os.path.exists(archive_path):
+def _verify_sha256(path: str, expected: str) -> bool:
+    """Return ``True`` if ``path`` matches the expected SHA256 hash."""
+    if not os.path.exists(path):
+        return False
+    hash_sha256 = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            hash_sha256.update(chunk)
+    return hash_sha256.hexdigest() == expected
+
+
+def download_qm9(data_dir: str = DEFAULT_DATA_DIR, *, url: str = URL, sha256: str = QM9_SHA256) -> None:
+    """Download and extract the QM9 dataset if necessary.
+
+    Parameters
+    ----------
+    data_dir:
+        Directory where the QM9 data should be stored. Defaults to ``QM9_DATA_DIR``
+        environment variable or ``qm9_raw``.
+    url:
+        Location of the dataset archive.
+    sha256:
+        Expected SHA256 hash of the archive for integrity checking.
+    """
+
+    os.makedirs(data_dir, exist_ok=True)
+    archive_path = os.path.join(data_dir, "gdb9.tar.gz")
+    if not _verify_sha256(archive_path, sha256):
         print("Downloading QM9 dataset...")
-        urllib.request.urlretrieve(URL, archive_path)
+        try:
+            urllib.request.urlretrieve(url, archive_path)
+        except Exception as e:  # pragma: no cover - network failure
+            raise RuntimeError(f"Failed to download QM9 dataset: {e}") from e
+        if not _verify_sha256(archive_path, sha256):
+            raise RuntimeError("Checksum mismatch for downloaded QM9 archive.")
         print("Download complete.")
-        with tarfile.open(archive_path, "r:gz") as tar:
-            tar.extractall(path="qm9_raw")
-            print("Extraction complete.")
+
+    if not os.path.exists(os.path.join(data_dir, "gdb9.sdf")):
+        try:
+            with tarfile.open(archive_path, "r:gz") as tar:
+                tar.extractall(path=data_dir)
+                print("Extraction complete.")
+        except tarfile.TarError as e:  # pragma: no cover - corrupted archive
+            os.remove(archive_path)
+            raise RuntimeError("Failed to extract QM9 archive. File may be corrupted and has been removed.") from e
 
 
-def load_qm9_chon(max_heavy: int = 12):
-    """Load molecules from the QM9 dataset restricted to C/H/O/N."""
-    import torch
+def load_qm9_chon(max_heavy: int = 12, data_dir: str = DEFAULT_DATA_DIR):
+    """Load molecules from the QM9 dataset restricted to C/H/O/N.
+
+    Parameters
+    ----------
+    max_heavy:
+        Maximum number of non-hydrogen atoms allowed in a molecule.
+    data_dir:
+        Location of the QM9 data directory.
+    """
+
+    try:
+        import torch
+    except ImportError as e:  # pragma: no cover - runtime check
+        raise ImportError(
+            "PyTorch is required to load QM9 data. Install it via 'pip install torch'."
+        ) from e
     try:
         from rdkit.Chem import rdmolfiles
     except ImportError as e:  # pragma: no cover - runtime check
@@ -32,10 +83,11 @@ def load_qm9_chon(max_heavy: int = 12):
             "RDKit is required to load QM9 data. Install it, e.g., via 'conda install -c conda-forge rdkit'."
         ) from e
 
-    if not os.path.exists("qm9_raw/gdb9.sdf"):
-        download_qm9()
+    sdf_path = os.path.join(data_dir, "gdb9.sdf")
+    if not os.path.exists(sdf_path):
+        download_qm9(data_dir)
     mols = []
-    suppl = rdmolfiles.SDMolSupplier("qm9_raw/gdb9.sdf")
+    suppl = rdmolfiles.SDMolSupplier(sdf_path)
     for mol in suppl:
         if mol is None:
             continue
@@ -52,8 +104,9 @@ def load_qm9_chon(max_heavy: int = 12):
 
 class QM9CHON_Dataset(Dataset):
     """Torch dataset for the filtered QM9 molecules."""
-    def __init__(self, max_heavy: int = 12):
-        self.data = load_qm9_chon(max_heavy)
+
+    def __init__(self, max_heavy: int = 12, data_dir: str = DEFAULT_DATA_DIR):
+        self.data = load_qm9_chon(max_heavy, data_dir)
 
     def __len__(self):
         return len(self.data)
@@ -62,6 +115,8 @@ class QM9CHON_Dataset(Dataset):
         return self.data[idx]
 
 
-def get_dataloader(batch_size: int = 32, max_heavy: int = 12):
-    dataset = QM9CHON_Dataset(max_heavy)
+def get_dataloader(batch_size: int = 32, max_heavy: int = 12, data_dir: str = DEFAULT_DATA_DIR):
+    """Return a dataloader over the filtered QM9 molecules."""
+
+    dataset = QM9CHON_Dataset(max_heavy, data_dir)
     return DataLoader(dataset, batch_size=batch_size, shuffle=True, collate_fn=lambda x: x)


### PR DESCRIPTION
## Summary
- allow overriding QM9 dataset directory via `QM9_DATA_DIR`
- verify QM9 downloads with SHA256 checksum and handle extraction errors
- document dataset location and integrity checking

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68904d8efc78832580e05791106a0450