### PR TITLE
Implement categorical sampling and expose trajectories

### DIFF
--- a/assembly_diffusion/sampler.py
+++ b/assembly_diffusion/sampler.py
@@ -1,4 +1,5 @@
-import random
+import torch
+from torch.distributions import Categorical
 
 from .mask import FeasibilityMask
 from .policy import ReversePolicy
@@ -10,14 +11,57 @@ class Sampler:
         self.policy = policy
         self.masker = mask
 
-    def sample(self, T: int, x_init: MoleculeGraph) -> MoleculeGraph:
+    def sample(self, T: int, x_init: MoleculeGraph, guidance=None) -> MoleculeGraph:
+        """Generate a single sample by running ``T`` reverse steps.
+
+        Parameters
+        ----------
+        T:
+            Number of reverse diffusion steps.
+        x_init:
+            Starting molecular graph at time ``T``.
+        guidance: callable, optional
+            Function modifying the logits before sampling. It must accept
+            ``(logits, x, t, mask)`` and return adjusted logits.
+        """
+
         x = x_init.copy()
         for t in range(T, 0, -1):
             mask = self.masker.mask_edits(x)
             logits = self.policy.logits(x, t, mask)
-            e = random.choice(list(mask.keys()))
-            if e == 'STOP':
+            if guidance is not None:
+                logits = guidance(logits, x, t, mask)
+            probs = torch.softmax(logits, dim=0)
+            dist = Categorical(probs)
+            idx = dist.sample().item()
+            action = self.policy._actions[idx]
+            if action == "STOP":
                 break
-            i, j, b = e
+            i, j, b = action
             x.bonds[i, j] = x.bonds[j, i] = b
         return x
+
+    def trajectory(self, T: int, x_init: MoleculeGraph, guidance=None):
+        """Return the sequence of intermediate graphs for diagnostics.
+
+        The returned list starts from ``x_init`` (``G_T``) and includes each
+        intermediate prediction down to the final ``Ĝ_0``.
+        """
+
+        x = x_init.copy()
+        traj = [x.copy()]
+        for t in range(T, 0, -1):
+            mask = self.masker.mask_edits(x)
+            logits = self.policy.logits(x, t, mask)
+            if guidance is not None:
+                logits = guidance(logits, x, t, mask)
+            probs = torch.softmax(logits, dim=0)
+            dist = Categorical(probs)
+            idx = dist.sample().item()
+            action = self.policy._actions[idx]
+            if action == "STOP":
+                break
+            i, j, b = action
+            x.bonds[i, j] = x.bonds[j, i] = b
+            traj.append(x.copy())
+        return traj


### PR DESCRIPTION
## Summary
- Use softmax over logits and Categorical sampling with optional guidance in sampler
- Add trajectory method to return intermediate graphs for diagnostics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689054dc959c83259788ba9a99bc60cf