### PR TITLE
Add evaluation utilities for molecule validity and metrics

### DIFF
--- a/assembly_diffusion/eval/metrics.py
+++ b/assembly_diffusion/eval/metrics.py
@@ -1,0 +1,82 @@
+"""Evaluation metrics for sets of molecular graphs."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence, Set, List
+
+try:  # pragma: no cover - RDKit optional
+    from rdkit import Chem
+except ImportError:  # pragma: no cover - handled at runtime
+    Chem = None
+
+from ..graph import MoleculeGraph
+from .validity import sanitize_or_none
+from ..ai_surrogate import AISurrogate
+
+
+
+def smiles_set(graphs: Iterable[MoleculeGraph]) -> Set[str]:
+    """Return a set of canonical SMILES for valid graphs."""
+
+    if Chem is None:
+        raise ImportError("RDKit is required to generate SMILES")
+    result: Set[str] = set()
+    for g in graphs:
+        mol = sanitize_or_none(g)
+        if mol is not None:
+            result.add(Chem.MolToSmiles(mol, canonical=True))
+    return result
+
+
+class Metrics:
+    """Basic metrics for evaluating generated molecules."""
+
+    @staticmethod
+    def evaluate(
+        sample_set: Sequence[MoleculeGraph],
+        train_smiles: Iterable[str],
+    ) -> dict[str, float]:
+        """Return validity, uniqueness and novelty for ``sample_set``."""
+
+        if Chem is None:
+            raise ImportError("RDKit is required to evaluate metrics")
+        total = len(sample_set)
+        if total == 0:
+            return {"validity": 0.0, "uniqueness": 0.0, "novelty": 0.0}
+
+        # Determine number of valid molecules
+        num_valid = sum(1 for g in sample_set if sanitize_or_none(g) is not None)
+
+        validity = num_valid / total
+        unique_smiles = smiles_set(sample_set)
+        uniqueness = len(unique_smiles) / num_valid if num_valid else 0.0
+        train_set = set(train_smiles)
+        novel = [s for s in unique_smiles if s not in train_set]
+        novelty = len(novel) / len(unique_smiles) if unique_smiles else 0.0
+        return {"validity": validity, "uniqueness": uniqueness, "novelty": novelty}
+
+
+class AIMetrics:
+    """Metrics for surrogate score trajectories."""
+
+    @staticmethod
+    def trajectory_scores(
+        trajectories: Sequence[Sequence[MoleculeGraph]],
+        surrogate: AISurrogate,
+    ) -> List[List[float]]:
+        """Return surrogate scores for each trajectory."""
+
+        return [[surrogate.score(g) for g in traj] for traj in trajectories]
+
+    @staticmethod
+    def monotonicity(score_sequences: Sequence[Sequence[float]]) -> float:
+        """Fraction of sequences with non-decreasing scores."""
+
+        seqs = [s for s in score_sequences if len(s) > 1]
+        if not seqs:
+            return 0.0
+        count = 0
+        for seq in seqs:
+            if all(seq[i] <= seq[i + 1] for i in range(len(seq) - 1)):
+                count += 1
+        return count / len(seqs)

--- a/assembly_diffusion/eval/validity.py
+++ b/assembly_diffusion/eval/validity.py
@@ -1,0 +1,32 @@
+"""Validation utilities for molecular graphs."""
+
+from __future__ import annotations
+
+from ..graph import MoleculeGraph
+
+
+
+def sanitize_or_none(graph: MoleculeGraph):
+    """Return a sanitized RDKit molecule or ``None``.
+
+    Parameters
+    ----------
+    graph:
+        The molecular graph to sanitize.
+
+    Returns
+    -------
+    rdkit.Chem.Mol | None
+        Sanitized molecule if successful, otherwise ``None``.
+    """
+
+    try:
+        return graph.to_rdkit()
+    except Exception:
+        return None
+
+
+def is_valid(graph: MoleculeGraph) -> bool:
+    """Return ``True`` if ``graph`` can be sanitized by RDKit."""
+
+    return sanitize_or_none(graph) is not None


### PR DESCRIPTION
## Summary
- add helpers to sanitize molecular graphs and test validity via RDKit
- compute validity, uniqueness, and novelty metrics plus surrogate trajectory metrics

## Testing
- `pip install torch --index-url https://download.pytorch.org/whl/cpu`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68906580449c83259b59107cb7a2dd75