### PR TITLE
Add triple bond support

### DIFF
--- a/assembly_diffusion/edit_vocab.py
+++ b/assembly_diffusion/edit_vocab.py
@@ -43,7 +43,7 @@ class EditVocab:
         """Enumerate all possible edits for ``x``.
 
         The edits are returned in a stable, deterministic order consisting of
-        all triples ``(i, j, b)`` with ``i < j`` and ``b`` in ``{0, 1, 2}``,
+        all triples ``(i, j, b)`` with ``i < j`` and ``b`` in ``{0, 1, 2, 3}``,
         followed by the ``STOP`` action.
         """
 
@@ -51,7 +51,7 @@ class EditVocab:
         edits: List[Edit] = []
         for i in range(n):
             for j in range(i + 1, n):
-                for b in [0, 1, 2]:
+                for b in [0, 1, 2, 3]:
                     edits.append(Edit(i, j, b))
         edits.append(EditVocab.STOP)
         return edits

--- a/assembly_diffusion/mask.py
+++ b/assembly_diffusion/mask.py
@@ -35,7 +35,7 @@ class FeasibilityMask:
         mask = {}
         for i in range(len(x.atoms)):
             for j in range(i + 1, len(x.atoms)):
-                for b in [0, 1, 2]:
+                for b in [0, 1, 2, 3]:
                     mask[(i, j, b)] = 1 if valence_check(x, i, j, b) else 0
         mask["STOP"] = 1
         return mask

--- a/assembly_diffusion/policy.py
+++ b/assembly_diffusion/policy.py
@@ -13,8 +13,8 @@ class ReversePolicy(nn.Module):
     def __init__(self, backbone: GNNBackbone):
         super().__init__()
         self.backbone = backbone
-        # Head predicting scores for bond orders 0, 1 or 2
-        self.edit_head = nn.Linear(backbone.node_dim * 2 + backbone.edge_dim, 3)
+        # Head predicting scores for bond orders 0, 1, 2 or 3
+        self.edit_head = nn.Linear(backbone.node_dim * 2 + backbone.edge_dim, 4)
         # Separate head for the stop action
         self.stop_head = nn.Linear(backbone.node_dim, 1)
         # Stores mapping from logits to semantic edits for sampling


### PR DESCRIPTION
## Summary
- enumerate bond edits with bond order 0-3
- validate feasibility mask for bond order 3
- expand policy head to output four bond-order logits

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6890814ce1ec8325b485713d5c262249