### PR TITLE
Add assembly index approximation and guidance prior

### DIFF
--- a/assembly_diffusion/__init__.py
+++ b/assembly_diffusion/__init__.py
@@ -13,4 +13,5 @@ __all__ = [
     "train",
     "edit_vocab",
     "ai_surrogate",
+    "assembly_index",
 ]

--- a/assembly_diffusion/assembly_index.py
+++ b/assembly_diffusion/assembly_index.py
@@ -1,0 +1,34 @@
+"""Approximate assembly index calculations."""
+
+from typing import Iterable
+
+from .graph import MoleculeGraph
+
+try:  # pragma: no cover - optional dependency
+    from rdkit import Chem
+    from rdkit.Chem import BRICS
+except ImportError:  # pragma: no cover - handled at runtime
+    Chem = None
+    BRICS = None
+
+
+def fragmenter(graph: MoleculeGraph) -> Iterable[str]:
+    """Return fragments for ``graph`` using BRICS cuts.
+
+    If RDKit is unavailable a crude fallback concatenates atomic symbols into a
+    single fragment.
+    """
+    if Chem is None or BRICS is None:
+        return ["".join(graph.atoms)]
+    mol = graph.to_rdkit()
+    return list(BRICS.BRICSDecompose(mol))
+
+
+def approx_AI(graph: MoleculeGraph) -> int:
+    """Fast upper bound on assembly depth.
+
+    The value is computed as the sum of the lengths of unique fragments
+    obtained from :func:`fragmenter`.
+    """
+    fragments = fragmenter(graph)
+    return sum(len(f) for f in set(fragments))

--- a/assembly_diffusion/guidance.py
+++ b/assembly_diffusion/guidance.py
@@ -2,6 +2,8 @@ import torch
 from torch import Tensor
 from typing import Tuple
 
+from .assembly_index import approx_AI
+
 
 def reweight(logits: Tensor, graph, delta_scores: Tensor, gamma: float, clip_range: Tuple[float, float]) -> Tensor:
     """Adjust policy logits using guidance scores.
@@ -37,3 +39,30 @@ def reweight(logits: Tensor, graph, delta_scores: Tensor, gamma: float, clip_ran
     adjustment = torch.clamp(delta_scores, min=a, max=b) * gamma
     adjusted[:-1] = adjusted[:-1] + adjustment
     return adjusted
+
+
+class AssemblyPrior:
+    """Simple prior based on an approximate assembly index."""
+
+    def __init__(self, coeff: float, target: int = 12) -> None:
+        """Create an assembly prior.
+
+        Parameters
+        ----------
+        coeff:
+            Scaling coefficient applied to the deviation from ``target``.
+        target:
+            Desired assembly index value. Actions increasing the index incur a
+            penalty on the logits.
+        """
+
+        self.coeff = coeff
+        self.target = target
+
+    def reweight(self, logits: Tensor, graph) -> Tensor:
+        """Penalise edits based on the approximate assembly index."""
+
+        ai = approx_AI(graph)
+        penalty = self.coeff * (ai - self.target)
+        logits[:-1] = logits[:-1] - penalty
+        return logits

--- a/tests/test_guidance.py
+++ b/tests/test_guidance.py
@@ -1,0 +1,17 @@
+import pathlib
+import sys
+
+import torch
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from assembly_diffusion.guidance import AssemblyPrior
+from assembly_diffusion.graph import MoleculeGraph
+
+
+def test_assembly_prior_reweight():
+    graph = MoleculeGraph(["C", "C"], torch.zeros((2, 2), dtype=torch.int64))
+    logits = torch.zeros(3)
+    prior = AssemblyPrior(coeff=0.5, target=1)
+    new_logits = prior.reweight(logits.clone(), graph)
+    expected = torch.tensor([-0.5, -0.5, 0.0])
+    assert torch.allclose(new_logits, expected)


### PR DESCRIPTION
## Summary
- implement `assembly_index` module with fragmenter and `approx_AI` for estimating assembly depth
- expose `AssemblyPrior` in `guidance` to penalize actions based on approximate assembly index
- include test for prior reweighting and package export updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68913671d8188325b50e2969931c614c