### PR TITLE
Add atom insertion actions

### DIFF
--- a/assembly_diffusion/mask.py
+++ b/assembly_diffusion/mask.py
@@ -1,7 +1,4 @@
-from .graph import MoleculeGraph, Chem
-
-
-VALENCE_CAP = {"C": 4, "N": 3, "O": 2, "H": 1}
+from .graph import MoleculeGraph, Chem, VALENCE_CAP, ALLOWED_ATOMS
 
 
 def valence_check(x: MoleculeGraph, i: int, j: int, b: int) -> bool:
@@ -29,13 +26,20 @@ def valence_check(x: MoleculeGraph, i: int, j: int, b: int) -> bool:
 
 
 class FeasibilityMask:
-    """Compute feasibility masks over possible bond edits."""
+    """Compute feasibility masks over possible edit actions."""
 
     def mask_edits(self, x: MoleculeGraph):
         mask = {}
+        # --- Bond edits -------------------------------------------------
         for i in range(len(x.atoms)):
             for j in range(i + 1, len(x.atoms)):
                 for b in [0, 1, 2, 3]:
                     mask[(i, j, b)] = 1 if valence_check(x, i, j, b) else 0
+
+        # --- Atom insertions -------------------------------------------
+        for i in x.free_valence_sites():
+            for atom in ALLOWED_ATOMS:
+                mask[("ADD", i, atom)] = 1
+
         mask["STOP"] = 1
         return mask

--- a/assembly_diffusion/sampler.py
+++ b/assembly_diffusion/sampler.py
@@ -51,8 +51,12 @@ class Sampler:
             action = self.policy._actions[idx]
             if action == "STOP":
                 break
-            i, j, b = action
-            x.bonds[i, j] = x.bonds[j, i] = b
+            if isinstance(action, tuple) and action and action[0] == "ADD":
+                _, site, atom = action
+                x.add_atom(atom, site)
+            else:
+                i, j, b = action
+                x.bonds[i, j] = x.bonds[j, i] = b
         return x
 
     def trajectory(
@@ -83,7 +87,11 @@ class Sampler:
             action = self.policy._actions[idx]
             if action == "STOP":
                 break
-            i, j, b = action
-            x.bonds[i, j] = x.bonds[j, i] = b
+            if isinstance(action, tuple) and action and action[0] == "ADD":
+                _, site, atom = action
+                x.add_atom(atom, site)
+            else:
+                i, j, b = action
+                x.bonds[i, j] = x.bonds[j, i] = b
             traj.append(x.copy())
         return traj


### PR DESCRIPTION
## Summary
- support stochastic atom insertion in forward diffusion kernel
- extend policy and mask to score and enumerate atom insertion edits
- allow sampler to apply atom insertion actions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689137d0e1f08325aa333ddda063e0a7