### PR TITLE
Add YAML config loader and example config

### DIFF
--- a/assembly_diffusion/__init__.py
+++ b/assembly_diffusion/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "guidance",
     "data",
     "train",
+    "config",
     "edit_vocab",
     "ai_surrogate",
     "ai_mc",

--- a/assembly_diffusion/config.py
+++ b/assembly_diffusion/config.py
@@ -1,0 +1,48 @@
+"""Configuration loading utilities for training."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+@dataclass
+class TrainConfig:
+    dataset: str
+    max_atoms: int
+    hidden_dim: int
+    optimiser: str
+    lr: float
+    batch: int
+    epochs: int
+    schedule: str
+    guid_coeff: float
+    guid_mode: str
+
+
+def load_config(path: str | Path, variant: str) -> TrainConfig:
+    """Load a YAML configuration file and return merged settings.
+
+    Parameters
+    ----------
+    path:
+        Path to a YAML file with ``common`` settings and model variants.
+    variant:
+        Key selecting one of the variant sections in the YAML file.
+    """
+
+    with open(Path(path), "r", encoding="utf8") as f:
+        raw: Dict[str, Any] = yaml.safe_load(f) or {}
+
+    common = raw.get("common", {})
+    if variant not in raw:
+        raise KeyError(f"Unknown variant '{variant}' in configuration")
+    specific = raw.get(variant, {})
+    merged: Dict[str, Any] = {**common, **specific}
+
+    missing = [k for k in TrainConfig.__annotations__ if k not in merged]
+    if missing:
+        raise KeyError(f"Missing keys in configuration: {missing}")
+
+    return TrainConfig(**merged)

--- a/configs/exp01.yaml
+++ b/configs/exp01.yaml
@@ -1,0 +1,18 @@
+common:
+  dataset: qm9_chon
+  max_atoms: 12
+  hidden_dim: 128
+  optimiser: adamw
+  lr: 3e-4
+  batch: 256
+  epochs: 300
+  schedule: cosine
+unguided:
+  guid_coeff: 0.0
+  guid_mode: none
+ai_guided:
+  guid_coeff: 0.5
+  guid_mode: exact_ai
+random_energy:
+  guid_coeff: 0.5
+  guid_mode: permuted

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 torch
+pyyaml
 # RDKit is optional and often easier to install via conda:
 # conda install -c conda-forge rdkit

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure the package root is on the path for test imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+from assembly_diffusion.config import load_config
+
+
+def test_load_config_ai_guided():
+    path = Path(__file__).resolve().parent.parent / "configs" / "exp01.yaml"
+    cfg = load_config(path, "ai_guided")
+    assert cfg.dataset == "qm9_chon"
+    assert cfg.hidden_dim == 128
+    assert cfg.guid_mode == "exact_ai"
+    assert cfg.guid_coeff == 0.5


### PR DESCRIPTION
## Summary
- add a YAML-based configuration loader with dataclass for training options
- expose the loader in package API
- provide an example experiment config and tests for merging common/variant settings

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689194d6e8d483259c5ca426394670dc