### PR TITLE
Add experiment pipeline script

### DIFF
--- a/scripts/experiment.py
+++ b/scripts/experiment.py
@@ -1,0 +1,161 @@
+
+"""High-level experiment driver for the Diffusion Assembly project.
+
+This script ties together the individual stages used throughout the experiments:
+
+1. **AI generation** via :func:`assembly_diffusion.qm9_ai.generate_qm9_chon_ai`.
+2. **Training** over all configuration variants located in ``configs``.
+3. **Sampling** a single molecule using the trained policy.
+4. **Analysis** using convenience utilities from :mod:`analysis`.
+
+The stages are deliberately lightweight so that the script can be executed in
+continuous integration environments.  A ``--smoke`` flag is provided to limit
+training to a single epoch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import yaml
+import torch
+
+# Ensure the repository root is on the Python path so we can import the local
+# modules when the script is executed as ``python scripts/experiment.py``.
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from assembly_diffusion.qm9_ai import generate_qm9_chon_ai
+from assembly_diffusion.config import load_config
+from assembly_diffusion.data import get_dataloader
+from assembly_diffusion.forward import ForwardKernel
+from assembly_diffusion.mask import FeasibilityMask
+from assembly_diffusion.backbone import GNNBackbone
+from assembly_diffusion.policy import ReversePolicy
+from assembly_diffusion.train import train_epoch
+from analysis import ks_test, sensitivity_over_lambda
+
+
+# ---------------------------------------------------------------------------
+# Individual experiment stages
+# ---------------------------------------------------------------------------
+
+def run_ai_generation() -> None:
+    """Generate assembly index annotations for the QM9 CHON subset."""
+    print("[AI generation] Creating QM9 annotations …")
+    generate_qm9_chon_ai()
+
+
+def train_all_configs(config_dir: str = "configs", *, smoke: bool = False) -> None:
+    """Train models for all configuration variants found in ``config_dir``.
+
+    Parameters
+    ----------
+    config_dir:
+        Directory containing YAML configuration files.
+    smoke:
+        If ``True``, restricts training to a single epoch for fast execution.
+    """
+
+    cfg_path = Path(config_dir)
+    for path in sorted(cfg_path.glob("*.yaml")):
+        with open(path, "r", encoding="utf8") as f:
+            raw = yaml.safe_load(f) or {}
+        variants = [k for k in raw.keys() if k != "common"]
+        for variant in variants:
+            cfg = load_config(path, variant)
+            print(f"[Training] {path.name}:{variant}")
+
+            loader = get_dataloader(batch_size=cfg.batch, max_heavy=cfg.max_atoms)
+            kernel = ForwardKernel()
+            mask = FeasibilityMask()
+            policy = ReversePolicy(GNNBackbone(node_dim=cfg.hidden_dim))
+            opt_cls = {
+                "adamw": torch.optim.AdamW,
+                "sgd": torch.optim.SGD,
+            }.get(cfg.optimiser.lower(), torch.optim.AdamW)
+            optimiser = opt_cls(policy.parameters(), lr=cfg.lr)
+
+            epochs = 1 if smoke else cfg.epochs
+            for epoch in range(epochs):
+                metrics = train_epoch(
+                    loader,
+                    kernel,
+                    policy,
+                    mask,
+                    optimiser,
+                    lambda_reg=cfg.guid_coeff,
+                    epoch=epoch,
+                )
+                print(
+                    f"  Epoch {epoch + 1}/{epochs} - loss: {metrics['loss']:.3f} "
+                    f"acc: {metrics['accuracy']:.3f}"
+                )
+
+
+def run_sampling() -> None:
+    """Draw a single sample from the current policy."""
+    from assembly_diffusion.graph import MoleculeGraph
+    from assembly_diffusion.sampler import Sampler
+
+    print("[Sampling] Drawing one molecule …")
+    torch.manual_seed(0)
+    x_init = MoleculeGraph(["C", "O"], torch.zeros((2, 2), dtype=torch.int64))
+    kernel = ForwardKernel()
+    mask = FeasibilityMask()
+    policy = ReversePolicy(GNNBackbone())
+    sampler = Sampler(policy, mask)
+    x = sampler.sample(kernel.T, x_init, gamma=1.0)
+    try:
+        print("  Sampled SMILES:", x.canonical_smiles())
+    except Exception:
+        print("  Sampled molecule has no valid SMILES representation")
+
+
+def run_analysis() -> None:
+    """Run lightweight analysis on the generated data."""
+    import pandas as pd
+
+    print("[Analysis] Running statistical checks …")
+    path = ROOT / "qm9_chon_ai.csv"
+    if not path.exists():
+        print("  No data available for analysis")
+        return
+
+    df = pd.read_csv(path)
+    if df.empty:
+        print("  Dataset is empty – skipping analysis")
+        return
+
+    sample_a = df["ai_exact"].head(100)
+    sample_b = df["ai_surrogate"].head(100)
+    ks = ks_test(sample_a, sample_b)
+    sens = sensitivity_over_lambda(df.head(5))
+    print(f"  KS statistic: {ks['statistic']:.3f}, p-value: {ks['pvalue']:.3g}")
+    print("  Sensitivity medians:", sens)
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def main(smoke: bool = False) -> None:
+    """Execute the full experiment pipeline."""
+    run_ai_generation()
+    train_all_configs(smoke=smoke)
+    run_sampling()
+    run_analysis()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run the full experiment pipeline")
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="Run a lightweight configuration for quick checks",
+    )
+    args = parser.parse_args()
+    main(smoke=args.smoke)


### PR DESCRIPTION
## Summary
- add scripts/experiment.py to run AI generation, training, sampling, and analysis in one pipeline

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891b3405f4c8325a22e229be038b965