### PR TITLE
Add checkpoint integrity check to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
         run: |
           pip install --no-cache-dir -r env.lock
           pip install --no-cache-dir -e .
-      - name: Run tests and reproducibility checks
+      - name: Run tests, reproducibility, and integrity checks
         run: |
           pytest
           python reproduce.py --smoke
+          python check_integrity.py

--- a/check_integrity.py
+++ b/check_integrity.py
@@ -1,0 +1,47 @@
+import glob
+import os
+import subprocess
+import sys
+
+import torch
+
+
+def main() -> None:
+    """Verify that checkpoints were created from the current commit.
+
+    For every ``*.pt`` file in the ``checkpoints`` directory, this script
+    expects a ``commit`` entry containing the git hash of the source code used
+    to create the checkpoint.  The hash must match the repository's HEAD.
+    """
+    try:
+        head = (
+            subprocess.check_output(["git", "rev-parse", "HEAD"])\
+            .decode("utf-8").strip()
+        )
+    except subprocess.CalledProcessError as exc:
+        print(f"Unable to determine git commit: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+
+    ok = True
+    for path in glob.glob(os.path.join("checkpoints", "*.pt")):
+        try:
+            data = torch.load(path, map_location="cpu")
+        except Exception as exc:  # pragma: no cover - best effort load
+            print(f"Failed to load {path}: {exc}", file=sys.stderr)
+            ok = False
+            continue
+        commit = data.get("commit")
+        if commit != head:
+            print(
+                f"Commit mismatch for {path}: expected {head}, got {commit}",
+                file=sys.stderr,
+            )
+            ok = False
+    if not ok:
+        raise SystemExit(1)
+
+    print("Checkpoint integrity verified")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to verify that checkpoints were produced from current git commit
- run integrity check in CI alongside existing tests

## Testing
- `pytest`
- `python reproduce.py --smoke`
- `python check_integrity.py`


------
https://chatgpt.com/codex/tasks/task_e_6891b6388f6c8325a5f803686ed911b7