### PR TITLE
Enable optional GPU acceleration

### DIFF
--- a/assembly_diffusion/backbone.py
+++ b/assembly_diffusion/backbone.py
@@ -64,7 +64,9 @@ class GNNBackbone(nn.Module):
         n = len(x.atoms)
 
         # --- Node features -------------------------------------------------
-        atom_ids = torch.tensor([ATOM_MAP.get(a, 0) for a in x.atoms])
+        atom_ids = torch.tensor(
+            [ATOM_MAP.get(a, 0) for a in x.atoms], device=x.bonds.device
+        )
         atom_feat = F.one_hot(atom_ids, num_classes=len(ATOM_TYPES)).float()
 
         degree = (x.bonds > 0).sum(dim=1).clamp(max=4)

--- a/assembly_diffusion/cli.py
+++ b/assembly_diffusion/cli.py
@@ -13,11 +13,13 @@ def sample_demo():
         from .sampler import Sampler
     except ModuleNotFoundError as exc:
         raise SystemExit(f"Missing dependency: {exc.name}")
-
-    x_init = MoleculeGraph(['C', 'O'], torch.zeros((2, 2)))
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    x_init = MoleculeGraph(
+        ['C', 'O'], torch.zeros((2, 2), dtype=torch.int64, device=device)
+    )
     kernel = ForwardKernel()
     mask = FeasibilityMask()
-    policy = ReversePolicy(GNNBackbone())
+    policy = ReversePolicy(GNNBackbone()).to(device)
     sampler = Sampler(policy, mask)
     x = sampler.sample(kernel.T, x_init)
     print(x.canonical_smiles())

--- a/assembly_diffusion/graph.py
+++ b/assembly_diffusion/graph.py
@@ -73,7 +73,9 @@ class MoleculeGraph:
         n = len(self.atoms)
         self.atoms.append(atom)
         # Expand bond matrix with zeros and connect the new atom
-        new_bonds = torch.zeros((n + 1, n + 1), dtype=self.bonds.dtype)
+        new_bonds = torch.zeros(
+            (n + 1, n + 1), dtype=self.bonds.dtype, device=self.bonds.device
+        )
         new_bonds[:n, :n] = self.bonds
         new_bonds[n, attach_site] = new_bonds[attach_site, n] = bond_order
         self.bonds = new_bonds

--- a/sample.py
+++ b/sample.py
@@ -10,6 +10,8 @@ from assembly_diffusion.policy import ReversePolicy
 from assembly_diffusion.sampler import Sampler
 from assembly_diffusion.guidance import AssemblyPrior
 
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
 
 def main():
     """Generate samples and save them to ``sample.parquet``.
@@ -21,10 +23,12 @@ def main():
 
     torch.manual_seed(0)
 
-    x_init = MoleculeGraph(["C", "O"], torch.zeros((2, 2), dtype=torch.int64))
+    x_init = MoleculeGraph(
+        ["C", "O"], torch.zeros((2, 2), dtype=torch.int64, device=DEVICE)
+    )
     kernel = ForwardKernel()
     mask = FeasibilityMask()
-    policy = ReversePolicy(GNNBackbone())
+    policy = ReversePolicy(GNNBackbone()).to(DEVICE)
     sampler = Sampler(policy, mask)
 
     prior = AssemblyPrior(coeff=0.5, target=12)


### PR DESCRIPTION
## Summary
- add GPU-aware tensor allocation in MoleculeGraph and GNN backbone
- detect CUDA and move models/tensors onto GPU in experiment, sample script and CLI demo

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891de53552c8325b33e4d542f1aad3d