### PR TITLE
Optimize GPU data loading for faster training

### DIFF
--- a/assembly_diffusion/data.py
+++ b/assembly_diffusion/data.py
@@ -141,4 +141,11 @@ def get_dataloader(batch_size: int = 32, max_heavy: int = 12, data_dir: str = DE
     """Return a dataloader over the filtered QM9 molecules."""
 
     dataset = QM9CHON_Dataset(max_heavy, data_dir)
-    return DataLoader(dataset, batch_size=batch_size, shuffle=True, collate_fn=collate_graphs)
+    return DataLoader(
+        dataset,
+        batch_size=batch_size,
+        shuffle=True,
+        collate_fn=collate_graphs,
+        pin_memory=torch.cuda.is_available(),
+        num_workers=min(4, os.cpu_count() or 0),
+    )

--- a/assembly_diffusion/train.py
+++ b/assembly_diffusion/train.py
@@ -45,13 +45,14 @@ def train_epoch(loader, kernel: ForwardKernel, policy: ReversePolicy,
     policy.train()
     metrics = {"loss": 0.0, "accuracy": 0.0, "n": 0}
     global_step = epoch * len(loader)
+    device = next(policy.parameters()).device
 
     if ckpt_interval:
         os.makedirs("checkpoints", exist_ok=True)
 
     for i, (atom_tensor, bond_tensor) in enumerate(loader):
         optimizer.zero_grad()
-        device = next(policy.parameters()).device
+        bond_tensor = bond_tensor.to(device, non_blocking=True)
 
         # --- Construct batched MoleculeGraph ------------------------------
         atom_lists = []
@@ -61,7 +62,7 @@ def train_epoch(loader, kernel: ForwardKernel, policy: ReversePolicy,
                 atom_lists.append([ATOM_TYPES[i] for i in atom_ids])
             else:
                 atom_lists.append(list(atoms))
-        x0 = MoleculeGraph(atom_lists, bond_tensor.to(device))
+        x0 = MoleculeGraph(atom_lists, bond_tensor)
 
         B = len(atom_lists)
         t = torch.randint(1, kernel.T + 1, (B,), device=device)


### PR DESCRIPTION
## Summary
- use pinned memory and worker processes when loading QM9 data
- avoid repeated device lookups and enable non-blocking GPU transfers during training

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891e01c95d88325ac20bd45dd95cc4d