### PR TITLE
Fix docstring escape sequence

### DIFF
--- a/assembly_diffusion/backbone.py
+++ b/assembly_diffusion/backbone.py
@@ -29,7 +29,7 @@ class GraphConv(nn.Module):
 
 
 def time_embedding(t: int, dim: int) -> torch.Tensor:
-    """Sinusoidal time embedding :math:`\psi(t)` of dimension ``dim``."""
+    """Sinusoidal time embedding :math:`\\psi(t)` of dimension ``dim``."""
 
     half = dim // 2
     freqs = torch.exp(


### PR DESCRIPTION
## Summary
- escape backslash in time_embedding docstring to avoid invalid escape sequence warning

## Testing
- `python scripts/experiment.py --smoke` *(fails: No module named 'yaml')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689311a0f0408325b486ad8902ab4ae2