### PR TITLE
Decouple heartbeat from training loop

### DIFF
--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -1,0 +1,17 @@
+import json
+import time
+from pathlib import Path
+
+from assembly_diffusion.monitor import RunMonitor
+
+
+def test_heartbeat_thread_runs(tmp_path):
+    m = RunMonitor(tmp_path, use_tb=False, hb_interval=0.1)
+    # Allow heartbeat thread to emit at least once
+    time.sleep(0.25)
+    m.close()
+    hb_file = Path(tmp_path) / "heartbeat.json"
+    assert hb_file.exists()
+    with hb_file.open() as f:
+        hb = json.load(f)
+    assert "time" in hb and "step" in hb


### PR DESCRIPTION
## Summary
- Send heartbeat updates on a dedicated timer thread instead of piggybacking on resource snapshots
- Add tests for new heartbeat monitor thread

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896676fa1a483259c6fce845f4dfce4