### PR TITLE
Add cross-platform sentinel polling

### DIFF
--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -15,3 +15,12 @@ def test_heartbeat_thread_runs(tmp_path):
     with hb_file.open() as f:
         hb = json.load(f)
     assert "time" in hb and "step" in hb
+
+
+def test_sentinel_poll(tmp_path):
+    m = RunMonitor(tmp_path, use_tb=False)
+    (tmp_path / "dump").touch()
+    (tmp_path / "checkpoint").touch()
+    ckpt, dump = m.poll()
+    assert ckpt and dump
+    m.close()


### PR DESCRIPTION
## Summary
- add sentinel files for dump and checkpoint requests to RunMonitor
- poll these files during training to trigger checkpoints or dumps
- test sentinel polling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896934b0ee48325bc78a359cf0fc0e2