### PR TITLE
Log checkpoint metadata and resume

### DIFF
--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -24,3 +24,31 @@ def test_sentinel_poll(tmp_path):
     ckpt, dump = m.poll()
     assert ckpt and dump
     m.close()
+
+
+def test_checkpoint_event_has_metadata(tmp_path):
+    ckpt = tmp_path / "ckpt.bin"
+    data = b"checkpoint-data"
+    ckpt.write_bytes(data)
+    m = RunMonitor(tmp_path, use_tb=False)
+    m.set_checkpoint(str(ckpt))
+    m.close()
+    events = [json.loads(l) for l in (tmp_path / "events.jsonl").read_text().splitlines()]
+    evt = next(e for e in events if e["kind"] == "checkpoint")
+    assert evt["path"] == str(ckpt)
+    assert evt["size_bytes"] == len(data)
+    import hashlib
+    assert evt["checksum"] == hashlib.sha256(data).hexdigest()
+
+
+def test_resume_event(tmp_path):
+    m = RunMonitor(tmp_path, use_tb=False, hb_interval=0.1)
+    src = "source.ckpt"
+    m.resume_from(src)
+    time.sleep(0.2)
+    m.close()
+    events = [json.loads(l) for l in (tmp_path / "events.jsonl").read_text().splitlines()]
+    evt = next(e for e in events if e["kind"] == "resume_ok")
+    assert evt["path"] == src
+    hb = json.loads((tmp_path / "heartbeat.json").read_text())
+    assert hb["last_ckpt"] == src


### PR DESCRIPTION
## Summary
- capture checkpoint file size and SHA-256 checksum in RunMonitor events
- record resume_ok events when restarting from a checkpoint
- test checkpoint metadata capture and resume event handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689699759810832596feaedf2bd531c1