### PR TITLE
Decouple heartbeat from resource sampling

### DIFF
--- a/tests/test_monitor.py
+++ b/tests/test_monitor.py
@@ -60,6 +60,7 @@ def test_drop_counter_and_retry(tmp_path):
     # stop background threads to control queue behavior
     m._stop.set()
     m._writer_thread.join()
+    m._hb_thread.join()
     m._sampler_thread.join()
 
     class DummyQ:


### PR DESCRIPTION
## Summary
- add dedicated heartbeat thread so liveness checks run even if resource sampling stalls
- move resource sampling to its own thread
- update tests for new heartbeat thread

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896a901c550832595cd29c5f2e745b5