### PR TITLE
fix data and train modules with explicit typing

### DIFF
--- a/assembly_diffusion/data.py
+++ b/assembly_diffusion/data.py
@@ -63,7 +63,9 @@ def download_qm9(data_dir: str = DEFAULT_DATA_DIR, *, url: str = URL, sha256: st
             raise RuntimeError("Failed to extract QM9 archive. File may be corrupted and has been removed.") from e
 
 
-def load_qm9_chon(max_heavy: int = 12, data_dir: str = DEFAULT_DATA_DIR):
+def load_qm9_chon(
+    max_heavy: int = 12, data_dir: str = DEFAULT_DATA_DIR
+) -> list[MoleculeGraph]:
     """Load molecules from the QM9 dataset restricted to C/H/O/N.
 
     Parameters
@@ -72,6 +74,11 @@ def load_qm9_chon(max_heavy: int = 12, data_dir: str = DEFAULT_DATA_DIR):
         Maximum number of non-hydrogen atoms allowed in a molecule.
     data_dir:
         Location of the QM9 data directory.
+
+    Returns
+    -------
+    list[MoleculeGraph]
+        Filtered molecules represented as :class:`MoleculeGraph` objects.
     """
 
     try:
@@ -119,7 +126,7 @@ class QM9CHON_Dataset(Dataset):
         return self.data[idx]
 
 
-def collate_graphs(batch):
+def collate_graphs(batch: list[MoleculeGraph]) -> tuple[torch.Tensor, torch.Tensor]:
     """Pack a list of :class:`MoleculeGraph` objects into padded tensors."""
 
     atom_ids = [
@@ -137,7 +144,9 @@ def collate_graphs(batch):
     return atom_tensor, bond_tensor
 
 
-def get_dataloader(batch_size: int = 32, max_heavy: int = 12, data_dir: str = DEFAULT_DATA_DIR):
+def get_dataloader(
+    batch_size: int = 32, max_heavy: int = 12, data_dir: str = DEFAULT_DATA_DIR
+) -> DataLoader:
     """Return a dataloader over the filtered QM9 molecules."""
 
     dataset = QM9CHON_Dataset(max_heavy, data_dir)

--- a/assembly_diffusion/train.py
+++ b/assembly_diffusion/train.py
@@ -2,6 +2,8 @@ import os
 import random
 import logging
 import time
+from typing import Union
+
 import torch
 
 from .forward import ForwardKernel
@@ -15,7 +17,7 @@ from .monitor import RunMonitor
 logger = logging.getLogger(__name__)
 
 
-def teacher_edit(x0: MoleculeGraph, xt: MoleculeGraph):
+def teacher_edit(x0: MoleculeGraph, xt: MoleculeGraph) -> Union[str, tuple[int, int, int]]:
     """Return a random edit transforming ``xt`` toward ``x0`` or ``STOP`` if none."""
     diff = []
     n = len(x0.atoms)
@@ -42,7 +44,7 @@ def train_epoch(
     writer=None,
     ckpt_interval: int | None = 500,
     monitor: RunMonitor | None = None,
-):
+) -> dict[str, float]:
     """Train ``policy`` for one epoch over ``loader``.
 
     The ``loader`` is expected to yield tuples ``(atom_tensor, bond_tensor)``


### PR DESCRIPTION
## Summary
- clarify QM9 data loader with return types and docstrings
- type hint training helpers for clearer APIs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896ba58696483259dee1317ddbeda13