### PR TITLE
Add string and tree calibrator utilities with analysis scripts

### DIFF
--- a/assembly_diffusion/assembly_index.py
+++ b/assembly_diffusion/assembly_index.py
@@ -32,3 +32,24 @@ def approx_AI(graph: MoleculeGraph) -> int:
     """
     fragments = fragmenter(graph)
     return sum(len(f) for f in set(fragments))
+
+from .calibrators.strings import StringGrammar
+from .calibrators.trees import TreeGrammar
+
+
+class AssemblyIndex:
+    @staticmethod
+    def A_star_S(x: str) -> int:
+        return StringGrammar.A_star(x)
+
+    @staticmethod
+    def D_min_S(x: str) -> int:
+        return StringGrammar.D_min(x)
+
+    @staticmethod
+    def A_star_T(G) -> int:
+        return TreeGrammar.A_star(G)
+
+    @staticmethod
+    def D_min_T(G, N_limit: int = 9) -> int:
+        return TreeGrammar.D_min_exact(G, N_limit=N_limit)

--- a/assembly_diffusion/calibrators/sampler.py
+++ b/assembly_diffusion/calibrators/sampler.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+import random
+from typing import Dict, Any, Iterable
+import pandas as pd
+
+from .strings import StringGrammar
+from .trees import TreeGrammar
+
+class Sampler:
+    def __init__(self, seed: int = 0):
+        self.rng = random.Random(seed)
+
+    def sample_S(self, L_max: int, n_samp: int, guided: bool = False, gamma: float = 0.0) -> pd.DataFrame:
+        gram = StringGrammar(L_max=L_max)
+        rows = []
+        for _ in range(n_samp):
+            L = gram.sample_target_length(guided=guided, gamma=gamma, rng=self.rng)
+            traj = gram.sample_trajectory(L, rng=self.rng)
+            x = gram.to_object(traj)
+            cid = gram.canonical_id(x)
+            A = gram.A_star(x)
+            rows.append({
+                "id": cid,
+                "universe": "S",
+                "grammar": f"S_v0_L{L_max}",
+                "As_lower": A,
+                "As_upper": A,
+                "validity": 1,
+                "frequency": 1.0,
+                "d_min": StringGrammar.D_min(x)
+            })
+        return pd.DataFrame(rows)
+
+    def sample_T(self, N_max: int, n_samp: int, guided: bool = False, gamma: float = 0.0, dmin_exact: bool = False) -> pd.DataFrame:
+        gram = TreeGrammar(N_max=N_max)
+        rows = []
+        for _ in range(n_samp):
+            N = gram.sample_target_N(guided=guided, gamma=gamma, rng=self.rng)
+            edges = gram.sample_trajectory(N, rng=self.rng)
+            G = gram.to_graph(edges)
+            cid = gram.canonical_id(G)
+            A = gram.A_star(G)
+            if dmin_exact and N <= 9:
+                dmin = gram.D_min_exact(G, N_limit=9)
+            else:
+                dmin = None
+            rows.append({
+                "id": cid,
+                "universe": "T",
+                "grammar": f"T_v0_N{N_max}",
+                "As_lower": A,
+                "As_upper": A,
+                "validity": 1,
+                "frequency": 1.0,
+                "d_min": dmin
+            })
+        return pd.DataFrame(rows)

--- a/assembly_diffusion/calibrators/strings.py
+++ b/assembly_diffusion/calibrators/strings.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+import random
+from dataclasses import dataclass
+from typing import List, Tuple, Dict
+
+Alphabet = Tuple[str, ...]
+
+@dataclass
+class StringGrammar:
+    P: Alphabet = ("A", "B", "C")
+    L_max: int = 12
+
+    def sample_target_length(self, guided: bool = False, gamma: float = 0.0, rng: random.Random | None = None) -> int:
+        """Sample a target length.
+        Baseline: uniform over {1..L_max}. Guided: geometric tilt toward larger lengths via softmax weights w(l) = exp(gamma * l).
+        """
+        rng = rng or random
+        if not guided or gamma == 0.0:
+            return rng.randint(1, self.L_max)
+        weights = [pow(2.718281828, gamma * l) for l in range(1, self.L_max + 1)]
+        total = sum(weights)
+        r = rng.random() * total
+        acc = 0.0
+        for l, w in zip(range(1, self.L_max + 1), weights):
+            acc += w
+            if r <= acc:
+                return l
+        return self.L_max
+
+    def sample_trajectory(self, length: int, rng: random.Random | None = None) -> List[str]:
+        """Path-uniform over symbol insertions of fixed length."""
+        rng = rng or random
+        return [rng.choice(self.P) for _ in range(length)]
+
+    @staticmethod
+    def to_object(traj: List[str]) -> str:
+        return "".join(traj)
+
+    @staticmethod
+    def canonical_id(x: str) -> str:
+        # Identity is fine for strings
+        return x
+
+    @staticmethod
+    def A_star(x: str) -> int:
+        return len(x)
+
+    @staticmethod
+    def D_min(x: str) -> int:
+        # Under simple concatenation with atomic symbols, there is only 1 minimal pathway per string.
+        return 1

--- a/assembly_diffusion/calibrators/trees.py
+++ b/assembly_diffusion/calibrators/trees.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+import itertools
+import random
+from dataclasses import dataclass
+from typing import List, Tuple, Dict, Set
+import networkx as nx
+
+@dataclass
+class TreeGrammar:
+    N_max: int = 10
+
+    def sample_target_N(self, guided: bool = False, gamma: float = 0.0, rng: random.Random | None = None) -> int:
+        """Sample target number of nodes.
+        Baseline: uniform over {2..N_max}. Guided: softmax tilt toward larger N via exp(gamma * N).
+        """
+        rng = rng or random
+        if not guided or gamma == 0.0:
+            return rng.randint(2, self.N_max)
+        Ns = list(range(2, self.N_max + 1))
+        weights = [pow(2.718281828, gamma * n) for n in Ns]
+        total = sum(weights)
+        r = rng.random() * total
+        acc = 0.0
+        for n, w in zip(Ns, weights):
+            acc += w
+            if r <= acc:
+                return n
+        return self.N_max
+
+    @staticmethod
+    def sample_trajectory(N: int, rng: random.Random | None = None) -> List[Tuple[int, int]]:
+        """Path-uniform minimal attachment sequences: start from node 0, at step t attach new node t to a uniformly random existing node in {0..t-1}. Returns edge list.
+        """
+        rng = rng or random
+        edges: List[Tuple[int, int]] = []
+        for t in range(1, N):
+            parent = rng.randint(0, t - 1)
+            edges.append((parent, t))
+        return edges
+
+    @staticmethod
+    def to_graph(edges: List[Tuple[int, int]]) -> nx.Graph:
+        G = nx.Graph()
+        for u, v in edges:
+            G.add_edge(u, v)
+        return G
+
+    @staticmethod
+    def canonical_id(G: nx.Graph) -> str:
+        # Use graph6 canonical string as an isomorphism-invariant id.
+        # Relabel nodes to 0..n-1 in some deterministic order first.
+        H = nx.convert_node_labels_to_integers(G, label_attribute=None)
+        return nx.to_graph6_bytes(H, header=False).decode("ascii")
+
+    @staticmethod
+    def A_star(G: nx.Graph) -> int:
+        # Minimal steps = N - 1 for a tree with N nodes.
+        return G.number_of_nodes() - 1
+
+    @staticmethod
+    def D_min_exact(G: nx.Graph, N_limit: int = 9) -> int:
+        """Exact count of distinct minimal attachment sequences up to graph isomorphism for small N.
+        This enumerates all sequences that attach node t to any existing node in {0..t-1}, then filters by those yielding an isomorphic graph.
+        Complexity grows ~ O(N!); restrict to N ≤ 9.
+        """
+        N = G.number_of_nodes()
+        if N > N_limit:
+            raise ValueError(f"D_min exact enumeration limited to N ≤ {N_limit}; got N={N}")
+        target_id = TreeGrammar.canonical_id(G)
+        count = 0
+        parent_choices = [list(range(t)) for t in range(1, N)]
+        for parents in itertools.product(*parent_choices):
+            edges = [(parents[t-1], t) for t in range(1, N)]
+            G_seq = TreeGrammar.to_graph(edges)
+            if TreeGrammar.canonical_id(G_seq) == target_id:
+                count += 1
+        return count

--- a/assembly_diffusion/monitor.py
+++ b/assembly_diffusion/monitor.py
@@ -396,3 +396,25 @@ class RunMonitor:
             self._dropped = 0
         if dropped:
             self._event("dropped_events", count=dropped)
+
+from dataclasses import dataclass
+import csv
+
+
+@dataclass
+class CSVLogger:
+    path: str
+    newline: str = "\n"
+
+    def open(self):
+        self._fh = open(self.path, "w", newline="")
+        self._writer = csv.writer(self._fh)
+        self._writer.writerow(["id","universe","grammar","As_lower","As_upper","validity","frequency","d_min"])
+        return self
+
+    def write_row(self, *row):
+        self._writer.writerow(row)
+
+    def close(self):
+        if getattr(self, "_fh", None):
+            self._fh.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ statsmodels
 rdkit-pypi; python_version < "3.12"
 # RDKit is optional and often easier to install via conda:
 # conda install -c conda-forge rdkit
+
+networkx

--- a/scripts/analyze_calibrators.py
+++ b/scripts/analyze_calibrators.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+import argparse
+import numpy as np
+import pandas as pd
+from typing import Tuple
+from math import log
+from scipy.stats import spearmanr
+
+parser = argparse.ArgumentParser()
+parser.add_argument("csv", type=str)
+parser.add_argument("--alpha", type=float, default=0.05)
+parser.add_argument("--boot", type=int, default=1000)
+
+
+def fit_logfreq_vs_A(df: pd.DataFrame, trim_quant: float = 0.05) -> Tuple[float, float, float]:
+    df = df.copy()
+    df["A"] = df["As_upper"].astype(int)
+    grouped = df.groupby("A")["frequency"].sum().reset_index()
+    lo, hi = grouped["A"].quantile([trim_quant, 1 - trim_quant])
+    mask = (grouped["A"] >= lo) & (grouped["A"] <= hi)
+    trimmed = grouped[mask]
+    X = trimmed["A"].to_numpy()
+    y = np.log(np.maximum(trimmed["frequency"].to_numpy(), 1e-12))
+    A = np.vstack([X, np.ones_like(X)]).T
+    m, c = np.linalg.lstsq(A, y, rcond=None)[0]
+    yhat = m * X + c
+    ss_res = np.sum((y - yhat)**2)
+    ss_tot = np.sum((y - np.mean(y))**2)
+    r2 = 1.0 - ss_res / ss_tot if ss_tot > 0 else 0.0
+    return float(m), float(c), float(r2)
+
+
+def bootstrap_ci(df: pd.DataFrame, alpha: float = 0.05, B: int = 1000) -> Tuple[float, float]:
+    m_vals = []
+    for _ in range(B):
+        resampled = df.sample(n=len(df), replace=True)
+        try:
+            m, c, r2 = fit_logfreq_vs_A(resampled)
+            m_vals.append(m)
+        except Exception:
+            continue
+    m_vals = np.array(m_vals)
+    lo = np.quantile(m_vals, alpha/2)
+    hi = np.quantile(m_vals, 1 - alpha/2)
+    return float(lo), float(hi)
+
+
+def degeneracy_spearman(df: pd.DataFrame) -> Tuple[float, float]:
+    sub = df.dropna(subset=["d_min"]).copy()
+    if sub.empty:
+        return np.nan, np.nan
+    sub["A"] = sub["As_upper"].astype(int)
+    rhos = []
+    ps = []
+    for A, g in sub.groupby("A"):
+        if g["d_min"].nunique() > 1 and g.shape[0] >= 4:
+            rho, p = spearmanr(g["frequency"], g["d_min"])
+            rhos.append(rho); ps.append(p)
+    if not rhos:
+        return np.nan, np.nan
+    return float(np.nanmean(rhos)), float(np.nanmean(ps))
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    df = pd.read_csv(args.csv)
+    m, c, r2 = fit_logfreq_vs_A(df)
+    m_lo, m_hi = bootstrap_ci(df, alpha=args.alpha, B=args.boot)
+    rho, p = degeneracy_spearman(df)
+    print({
+        "m": m,
+        "m_CI": [m_lo, m_hi],
+        "R2": r2,
+        "rho_deg": rho,
+        "p_deg": p,
+        "N_rows": int(df.shape[0])
+    })

--- a/scripts/run_calibrators.py
+++ b/scripts/run_calibrators.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+import argparse
+import pandas as pd
+from assembly_diffusion.calibrators.sampler import Sampler
+from assembly_diffusion.monitor import CSVLogger
+
+parser = argparse.ArgumentParser()
+parser.add_argument("universe", choices=["S", "T"], help="Calibrator universe")
+parser.add_argument("--n_samp", type=int, default=20000)
+parser.add_argument("--L_max", type=int, default=12)
+parser.add_argument("--N_max", type=int, default=10)
+parser.add_argument("--guided", action="store_true")
+parser.add_argument("--gamma", type=float, default=0.0)
+parser.add_argument("--seed", type=int, default=0)
+parser.add_argument("--out", type=str, default="calibrator_samples.csv")
+parser.add_argument("--dmin_exact", action="store_true")
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    S = Sampler(seed=args.seed)
+    if args.universe == "S":
+        df = S.sample_S(L_max=args.L_max, n_samp=args.n_samp, guided=args.guided, gamma=args.gamma)
+    else:
+        df = S.sample_T(N_max=args.N_max, n_samp=args.n_samp, guided=args.guided, gamma=args.gamma, dmin_exact=args.dmin_exact)
+    freq = df.groupby(["id","universe","grammar","As_lower","As_upper","validity","d_min"]).size().reset_index(name="count")
+    freq["frequency"] = freq["count"] / freq["count"].sum()
+    freq = freq.drop(columns=["count"])
+    freq.to_csv(args.out, index=False)
+    print(f"Wrote {len(freq)} rows to {args.out}")

--- a/tests/test_calibrators.py
+++ b/tests/test_calibrators.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+import pandas as pd
+from assembly_diffusion.calibrators.strings import StringGrammar
+from assembly_diffusion.calibrators.trees import TreeGrammar
+from assembly_diffusion.calibrators.sampler import Sampler
+
+
+def test_Astar_strings():
+    assert StringGrammar.A_star("") == 0
+    assert StringGrammar.A_star("ABC") == 3
+
+
+def test_sampler_S_shapes():
+    S = Sampler(seed=123)
+    df = S.sample_S(L_max=6, n_samp=100, guided=False)
+    assert (df["universe"] == "S").all()
+    assert df["As_lower"].min() >= 1
+    assert df["As_upper"].max() <= 6
+
+
+def test_Astar_trees():
+    gram = TreeGrammar(N_max=6)
+    edges = gram.sample_trajectory(6)
+    G = gram.to_graph(edges)
+    assert gram.A_star(G) == 5
+
+
+def test_sampler_T_shapes():
+    S = Sampler(seed=0)
+    df = S.sample_T(N_max=6, n_samp=100, guided=False)
+    assert (df["universe"] == "T").all()
+    assert (df["As_upper"] == df["As_lower"]).all()
+    assert df["As_upper"].min() >= 1


### PR DESCRIPTION
## Summary
- introduce calibrator grammars for strings and trees with exact A* and D_min
- add sampling utilities, CSV logger, and analysis scripts
- include unit tests and networkx dependency

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896c2c1d4d083258817ad6d52e3037b