### PR TITLE
Use batched guided sampler in CLI

### DIFF
--- a/assembly_diffusion/sampler.py
+++ b/assembly_diffusion/sampler.py
@@ -46,6 +46,8 @@ class Sampler:
                 delta = guidance(logits, x, t, mask)
                 logits = reweight(logits, x, delta, gamma, clip_range)
             probs = torch.softmax(logits, dim=0)
+            if not torch.isfinite(probs).any():
+                return x
             dist = Categorical(probs)
             idx = dist.sample().item()
             action = self.policy._actions[idx]
@@ -82,6 +84,8 @@ class Sampler:
                 delta = guidance(logits, x, t, mask)
                 logits = reweight(logits, x, delta, gamma, clip_range)
             probs = torch.softmax(logits, dim=0)
+            if not torch.isfinite(probs).any():
+                break
             dist = Categorical(probs)
             idx = dist.sample().item()
             action = self.policy._actions[idx]


### PR DESCRIPTION
## Summary
- add PolicyGrammarAdapter and BatchedPolicy to bridge feasibility mask and ReversePolicy
- swap CLI demo to use new batched guided sampler
- guard single-trajectory sampler against NaN probability rows and expose graph stats used by guidance

## Testing
- `python -m assembly_diffusion.cli sample`
- `python -m assembly_diffusion.cli sample --gamma 0.8 --guidance-mode A_lower` *(fails: KeyboardInterrupt during heavy scoring)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6896cd8aa6148325ab9e37e51f7bca89