### PR TITLE
docs: add objectives and grammar

### DIFF
--- a/docs/00_objectives.md
+++ b/docs/00_objectives.md
@@ -1,0 +1,9 @@
+# Objectives and Hypotheses
+
+Scope: QM9 CHON subset, N_heavy ≤ 12. Guidance = assembly index (AI) prior.
+
+H1 (Validity): AI-guided diffusion does not reduce RDKit-valid fraction vs unguided baseline (Δvalid ≤ 1% absolute at matched N).
+H2 (Plausibility/Complexity): AI-guided samples have lower median predicted assembly index than unguided baseline (Δmedian_AI < 0 with p<0.05).
+H3 (Diversity): AI guidance does not reduce uniqueness or internal diversity beyond 5% absolute.
+
+All claims conditional on grammar G and primitives P used for AI computation (declared in docs/01_grammar.md).

--- a/docs/01_grammar.md
+++ b/docs/01_grammar.md
@@ -1,0 +1,6 @@
+# Grammar and Primitives (G, P)
+
+- Chemical universe: CHON, valence {C:4, N:3, O:2}, neutral molecules, bond types: single/double (no aromatic v0).
+- Assembly index evaluator: [implementation path] `assembly_diffusion/assembly_index.py` with calibrations in `assembly_diffusion/calibrators`.
+
+Assumption: AI surrogate approximates exact AI; error bounds logged per run (see docs/02_surrogate.md).


### PR DESCRIPTION
## Summary
- establish study scope and hypotheses for AI-guided diffusion in `docs/00_objectives.md`
- document grammar and assembly index evaluator assumptions in `docs/01_grammar.md`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896d60021cc8325ad01dae5c66ae3b5