### PR TITLE
configs: add experiment schema and registry

### DIFF
--- a/configs/registry.yaml
+++ b/configs/registry.yaml
@@ -1,0 +1,20 @@
+experiments:
+  exp01_baseline:
+    description: "Unguided baseline on QM9-CHON, matched sampler settings."
+    dataset: {name: qm9_chon, split: test, limit: 5000}
+    seed: 42
+    model: {ckpt: null, steps: 1000, guidance: {enabled: false, weight: 0.0, policy: additive}}
+    ai: {scorer: exact, surrogate_ckpt: null, grammar: default}
+    sampler: {n_samples: 2000, batch_size: 128}
+    metrics: {rdkit: true, novelty: true, uniqueness: true, diversity: internal_tanimoto}
+    artifacts: {save_smiles: true, save_sdf: false, save_ai_scores: true}
+
+  exp02_guided_lambda1:
+    description: "Guided run, λ=1.0, exact AI."
+    dataset: {name: qm9_chon, split: test, limit: 5000}
+    seed: 42
+    model: {ckpt: null, steps: 1000, guidance: {enabled: true, weight: 1.0, policy: additive}}
+    ai: {scorer: exact, surrogate_ckpt: null, grammar: default}
+    sampler: {n_samples: 2000, batch_size: 128}
+    metrics: {rdkit: true, novelty: true, uniqueness: true, diversity: internal_tanimoto}
+    artifacts: {save_smiles: true, save_sdf: false, save_ai_scores: true}

--- a/configs/schema.yaml
+++ b/configs/schema.yaml
@@ -1,0 +1,31 @@
+# Documented schema for experiments
+name: str
+description: str
+dataset:
+  name: "qm9_chon"
+  split: "test|valid|train|all"
+  limit: int  # 0 = no limit
+seed: int
+model:
+  ckpt: str | null
+  steps: int
+  guidance:
+    enabled: bool
+    weight: float # λ in [0, 5] sensible range
+    policy: "additive|multiplicative"
+ai:
+  scorer: "exact|surrogate"
+  surrogate_ckpt: str | null
+  grammar: "default"
+sampler:
+  n_samples: int
+  batch_size: int
+metrics:
+  rdkit: true
+  novelty: true
+  uniqueness: true
+  diversity: "internal_tanimoto"
+artifacts:
+  save_smiles: true
+  save_sdf: false
+  save_ai_scores: true


### PR DESCRIPTION
## Summary
- document expected experiment fields in new `configs/schema.yaml`
- centralize named experiment settings in `configs/registry.yaml`

## Testing
- `pytest` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6896d7c56b288325a51d644fa28d98fc