### PR TITLE
surrogate: training plan with CV and artifact outputs

### DIFF
--- a/docs/02_surrogate.md
+++ b/docs/02_surrogate.md
@@ -1,0 +1,12 @@
+# Surrogate AI Model
+
+Target: Predict assembly index A*(x|G,P).
+Training: QM9-CHON split, labels from exact AI (timeout 1s/molecule; label drop if timeout).
+Validation: 5-fold CV. Metrics: MAE, RMSE. Target MAE ≤ 0.5 AI units.
+
+Uncertainty: Monte Carlo dropout (T=20) to estimate σ_pred. During guidance, clamp λ if σ_pred > σ_max.
+
+Artifacts saved per training:
+- model.pt
+- cv_metrics.json
+- calibration_plot.png

--- a/scripts/train_surrogate.py
+++ b/scripts/train_surrogate.py
@@ -1,0 +1,11 @@
+import json, os, time, numpy as np, torch
+from pathlib import Path
+
+# TODO: load features + labels, define model, train, k-fold, save metrics
+outdir = f"results/surrogate_train_{int(time.time())}"
+Path(outdir).mkdir(parents=True, exist_ok=True)
+metrics = {"mae": 0.0, "rmse": 0.0, "folds": []}  # fill real values
+json.dump(metrics, open(os.path.join(outdir,"cv_metrics.json"),"w"), indent=2)
+torch.save({"state_dict": None}, os.path.join(outdir,"model.pt"))
+open(os.path.join(outdir, "calibration_plot.png"), "wb").close()
+print(f"[OK] Surrogate artifacts -> {outdir}")


### PR DESCRIPTION
## Summary
- Document surrogate AI model including training data, 5-fold cross validation, uncertainty estimation, and required artifacts.
- Add `train_surrogate.py` skeleton that prepares output directory and saves placeholder model, metrics, and calibration plot.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896f74cc8b48325a80568b7fdaca932