### PR TITLE
eval: standard metrics writer and schema

### DIFF
--- a/assembly_diffusion/eval/metrics_writer.py
+++ b/assembly_diffusion/eval/metrics_writer.py
@@ -1,0 +1,19 @@
+import json
+import os
+from pathlib import Path
+
+SCHEMA_VERSION = "1.0"
+
+
+def write_metrics(outdir, *, valid_fraction, uniqueness, diversity, novelty, median_ai):
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "valid_fraction": float(valid_fraction),
+        "uniqueness": float(uniqueness),
+        "diversity": float(diversity),
+        "novelty": float(novelty),
+        "median_ai": float(median_ai),
+    }
+    Path(outdir).mkdir(parents=True, exist_ok=True)
+    with open(os.path.join(outdir, "metrics.json"), "w") as f:
+        json.dump(payload, f, indent=2)

--- a/scripts/experiment.py
+++ b/scripts/experiment.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from pathlib import Path
 
 import yaml
+from assembly_diffusion.eval.metrics_writer import write_metrics
 
 
 def _git_hash() -> str:
@@ -78,7 +79,14 @@ if __name__ == "__main__":
     # save SMILES
     # with open(os.path.join(outdir, "samples.smi"), "w") as f: ...
     # save metrics
-    # json.dump(metrics, open(os.path.join(outdir, "metrics.json"), "w"), indent=2)
+    # write_metrics(
+    #     outdir,
+    #     valid_fraction=...,  # fraction of valid structures
+    #     uniqueness=...,  # fraction of unique structures
+    #     diversity=...,  # pairwise Tanimoto diversity
+    #     novelty=...,  # fraction not seen in training
+    #     median_ai=...,  # median AI score
+    # )
     # save AI scores
     # np.savetxt(os.path.join(outdir, "ai_scores.csv"), ai_scores, delimiter=",")
 


### PR DESCRIPTION
## Summary
- add metrics writer with schema version
- document usage in experiment script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6896fb41b7248325a30b345cfb40b2e0