### PR TITLE
Silence git hash lookup when repo missing

### DIFF
--- a/scripts/experiment.py
+++ b/scripts/experiment.py
@@ -8,7 +8,9 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 def _git_hash():
     try:
-        return subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+        return subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL
+        ).decode().strip()
     except Exception:
         return "unknown"
 


### PR DESCRIPTION
## Summary
- Avoid git stderr noise when manifest retrieves revision in non-repo archives
- Keep experiment pipeline stub returning metrics schema

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689703a22a308325aaa776c4394d30be