### PR TITLE
Handle missing git repository gracefully

### DIFF
--- a/check_integrity.py
+++ b/check_integrity.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 import glob
+from pathlib import Path
 
 import torch
 
@@ -13,12 +14,20 @@ def main() -> None:
     expects a ``commit`` entry containing the git hash of the source code used
     to create the checkpoint.  The hash must match the repository's HEAD.
     """
+    repo_root = Path(__file__).resolve().parent
+    if not (repo_root / ".git").exists():
+        print("Unable to determine git commit: missing .git directory", file=sys.stderr)
+        raise SystemExit(1)
+
     try:
         head = (
-            subprocess.check_output(["git", "rev-parse", "HEAD"])\
-            .decode("utf-8").strip()
+            subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL, cwd=repo_root
+            )
+            .decode("utf-8")
+            .strip()
         )
-    except subprocess.CalledProcessError as exc:
+    except Exception as exc:
         print(f"Unable to determine git commit: {exc}", file=sys.stderr)
         raise SystemExit(1)
 

--- a/scripts/experiment.py
+++ b/scripts/experiment.py
@@ -8,10 +8,26 @@ from assembly_diffusion.pipeline import run_pipeline
 
 
 def _git_hash():
+    """Return the current git commit hash or ``"unknown"``.
+
+    When the project is executed from a zip archive the ``.git`` directory is
+    absent and invoking ``git`` would emit an error message.  To keep logs clean
+    we first check for ``.git`` and only then attempt to call ``git`` while
+    silencing any stderr output.
+    """
+
+    repo_root = Path(__file__).resolve().parents[1]
+    if not (repo_root / ".git").exists():
+        return "unknown"
+
     try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL
-        ).decode().strip()
+        return (
+            subprocess.check_output(
+                ["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL, cwd=repo_root
+            )
+            .decode()
+            .strip()
+        )
     except Exception:
         return "unknown"
 


### PR DESCRIPTION
## Summary
- avoid noisy errors when `.git` is absent by checking for it before calling git
- ensure checkpoint integrity script runs git quietly and handles missing repo metadata

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68970a3f092c8325ae2b66765c2ba3c0