### PR TITLE
Remove placeholder code and refine pipeline

### DIFF
--- a/assembly_diffusion/qm9_ai.py
+++ b/assembly_diffusion/qm9_ai.py
@@ -59,7 +59,10 @@ def generate_qm9_chon_ai(
             smiles = "".join(graph.atoms)
             scaffold = "NA"
             desc = [0.0] * 6
-        ai_exact = mc.ai(graph)
+        if hasattr(mc, "ai"):
+            ai_exact = mc.ai(graph)
+        else:
+            ai_exact = mc.estimate(graph)
         ai_surr = surrogate.score(graph)
         ai_conflict = int(round(ai_surr) != ai_exact)
         rows.append([smiles, ai_exact, ai_surr, scaffold, *desc, ai_conflict])


### PR DESCRIPTION
## Summary
- replace placeholder imports with optional sampler, dataset and AI utilities
- implement Monte-Carlo and surrogate assembly index scoring
- fix QM9 AI export to use available MC interface

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897108946cc832595e79c10ebb1a99d