### PR TITLE
Implement additive guidance with lambda schedule

### DIFF
--- a/docs/03_guidance.md
+++ b/docs/03_guidance.md
@@ -1,0 +1,14 @@
+# Guidance Equation
+
+We implement an additive guidance strategy for candidate actions.
+For a state $s$ and action $a$ the guided logits are
+
+$$\log \hat{p}(a\mid s) = \log p_\theta(a\mid s) - \lambda\,\hat{A}(s \oplus a)$$
+
+where $\hat{A}$ is the approximate assembly index of the successor state and
+$\lambda$ is a non-negative weight. During diffusion sampling $\lambda$ is
+increased linearly from $0$ to $\lambda_{\max}$ across the $T$ diffusion steps.
+
+The function `additive_guidance` in `assembly_diffusion.guidance` applies the
+above transformation, and `linear_lambda_schedule` provides the step-dependent
+$\lambda_t = \lambda_{\max}\, t/(T-1)$ schedule.

--- a/tests/test_guidance.py
+++ b/tests/test_guidance.py
@@ -7,7 +7,11 @@ import pytest
 torch = pytest.importorskip("torch")
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-from assembly_diffusion.guidance import AssemblyPrior
+from assembly_diffusion.guidance import (
+    AssemblyPrior,
+    additive_guidance,
+    linear_lambda_schedule,
+)
 from assembly_diffusion.graph import MoleculeGraph
 from assembly_diffusion.assembly_index import approx_AI
 
@@ -22,3 +26,34 @@ def test_assembly_prior_reweight():
     penalty = 0.5 * (ai - 1)
     expected = torch.tensor([-penalty, -penalty, 0.0])
     assert torch.allclose(new_logits, expected)
+
+
+class ToyGrammar:
+    """Minimal grammar returning preset ``Â`` scores."""
+
+    def __init__(self, scores):
+        self.scores = scores
+
+    def apply_action(self, state, action):
+        return action
+
+    def A_hat(self, state):
+        return self.scores[state]
+
+
+def test_additive_guidance_monotone():
+    grammar = ToyGrammar({"a": 1.0, "b": 3.0})
+    state = ""
+    actions = ["a", "b"]
+    A_vals = torch.tensor(
+        [grammar.A_hat(grammar.apply_action(state, a)) for a in actions]
+    )
+    logits = torch.zeros(len(actions))
+
+    lambdas = [linear_lambda_schedule(t, 3, 1.0) for t in range(3)]
+    probs = []
+    for lam in lambdas:
+        new_logits = additive_guidance(logits, A_vals, lam)
+        probs.append(torch.softmax(new_logits, dim=-1)[0].item())
+
+    assert probs[0] < probs[1] < probs[2]


### PR DESCRIPTION
## Summary
- expose additive guidance equation `log p_hat(a|s) = log p_theta(a|s) - lambda * A_hat(s⊕a)`
- add linear `lambda` schedule from 0 to `lambda_max`
- document guidance equation and provide toy-grammar unit test

## Testing
- `pytest tests/test_guidance.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68971aa9b8e08325beffbdf81bf3e4f6