### PR TITLE
Add λ ablations and AI controls

### DIFF
--- a/configs/registry.yaml
+++ b/configs/registry.yaml
@@ -18,3 +18,43 @@ experiments:
     sampler: {n_samples: 10, batch_size: 4}
     metrics: {rdkit: false, novelty: false, uniqueness: false, diversity: internal_tanimoto}
     artifacts: {save_smiles: true, save_sdf: false, save_ai_scores: true}
+
+  exp03_guided_lambda0p5:
+    description: "Guided run, λ=0.5, exact AI."
+    dataset: {name: qm9_chon, split: test, limit: 0}
+    seed: 42
+    model: {ckpt: null, steps: 5, guidance: {enabled: true, weight: 0.5, policy: additive}}
+    ai: {scorer: surrogate, surrogate_ckpt: dummy, grammar: default, calibration: {n_mols: 0}}
+    sampler: {n_samples: 10, batch_size: 4}
+    metrics: {rdkit: false, novelty: false, uniqueness: false, diversity: internal_tanimoto}
+    artifacts: {save_smiles: true, save_sdf: false, save_ai_scores: true}
+
+  exp04_guided_lambda2:
+    description: "Guided run, λ=2.0, exact AI."
+    dataset: {name: qm9_chon, split: test, limit: 0}
+    seed: 42
+    model: {ckpt: null, steps: 5, guidance: {enabled: true, weight: 2.0, policy: additive}}
+    ai: {scorer: surrogate, surrogate_ckpt: dummy, grammar: default, calibration: {n_mols: 0}}
+    sampler: {n_samples: 10, batch_size: 4}
+    metrics: {rdkit: false, novelty: false, uniqueness: false, diversity: internal_tanimoto}
+    artifacts: {save_smiles: true, save_sdf: false, save_ai_scores: true}
+
+  exp05_permuted_ai_control:
+    description: "Guided run, λ=1.0, permuted AI control."
+    dataset: {name: qm9_chon, split: test, limit: 0}
+    seed: 42
+    model: {ckpt: null, steps: 5, guidance: {enabled: true, weight: 1.0, policy: additive}}
+    ai: {scorer: surrogate, surrogate_ckpt: dummy, grammar: default, mode: permuted, calibration: {n_mols: 0}}
+    sampler: {n_samples: 10, batch_size: 4}
+    metrics: {rdkit: false, novelty: false, uniqueness: false, diversity: internal_tanimoto}
+    artifacts: {save_smiles: true, save_sdf: false, save_ai_scores: true}
+
+  exp06_null_ai_control:
+    description: "Guided run, λ=1.0, null AI control."
+    dataset: {name: qm9_chon, split: test, limit: 0}
+    seed: 42
+    model: {ckpt: null, steps: 5, guidance: {enabled: true, weight: 1.0, policy: additive}}
+    ai: {scorer: surrogate, surrogate_ckpt: dummy, grammar: default, mode: null, calibration: {n_mols: 0}}
+    sampler: {n_samples: 10, batch_size: 4}
+    metrics: {rdkit: false, novelty: false, uniqueness: false, diversity: internal_tanimoto}
+    artifacts: {save_smiles: true, save_sdf: false, save_ai_scores: true}

--- a/scripts/ab_compare.py
+++ b/scripts/ab_compare.py
@@ -28,6 +28,33 @@ if __name__ == "__main__":
         "diversity_delta": mB["diversity"] - mA["diversity"],
         "median_AI_delta": mB["median_ai"] - mA["median_ai"],
     }
+
+    rows = []
+    metrics = [
+        ("valid_fraction", "Validity"),
+        ("uniqueness", "Uniqueness"),
+        ("diversity", "Diversity"),
+        ("median_ai", "Median AI"),
+    ]
+    for key, label in metrics:
+        delta = mB[key] - mA[key]
+        ciA = mA.get(f"{key}_ci")
+        ciB = mB.get(f"{key}_ci")
+        if ciA and ciB:
+            delta_ci = [ciB[0] - ciA[1], ciB[1] - ciA[0]]
+        else:
+            delta_ci = None
+        rows.append((label, delta, delta_ci))
+
+    print("| Metric | Δ(B−A) | 95% CI |")
+    print("|---|---|---|")
+    for label, delta, ci in rows:
+        if ci:
+            ci_str = f"[{ci[0]:.3f}, {ci[1]:.3f}]"
+        else:
+            ci_str = "N/A"
+        print(f"| {label} | {delta:.3f} | {ci_str} |")
+
     print(json.dumps(summary, indent=2))
     with open("results/ab_summary.json","w") as f:
         json.dump(summary,f,indent=2)


### PR DESCRIPTION
## Summary
- extend experiment registry with λ=0.5 and λ=2.0 ablations
- add permuted-AI and null-AI control entries
- print delta and CI table in A/B comparison script

## Testing
- `pytest` *(fails: No module named 'yaml'; No module named 'torch')*
- `pip install pyyaml torch` *(failed: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_689726b6a08c8325b6b4787eb31c08bd