### PR TITLE
feat: enrich monitoring metadata and snapshots

### DIFF
--- a/assembly_diffusion/train.py
+++ b/assembly_diffusion/train.py
@@ -122,6 +122,12 @@ def train_epoch(
                 monitor.scalar("loss/train", float(batch_loss.detach().cpu()), step=step_in_epoch)
             except Exception:
                 pass
+        if monitor and (step_in_epoch % 100 == 0):
+            try:
+                smi = xt_graphs[0].canonical_smiles()
+                monitor.sample_smiles([smi], step=step_in_epoch)
+            except Exception:
+                pass
 
         if monitor and (time.time() - last_poke_check) > 5:
             ckpt_req, dump_req = monitor.poll()


### PR DESCRIPTION
## Summary
- record git hash and config in monitor events and heartbeat
- dump sample SMILES and checkpoint metadata for easier reproducibility
- capture periodic SMILES snapshots during training

## Testing
- `pytest tests/test_monitor.py`


------
https://chatgpt.com/codex/tasks/task_e_6897298273c483258674a3e711fa53b1