### PR TITLE
Document explicit grammar and primitives

### DIFF
--- a/docs/00_objectives.md
+++ b/docs/00_objectives.md
@@ -65,6 +65,5 @@ predicted assembly index than unguided baseline (Δmedian_AI < 0 with p <
 H3 (Diversity): AI guidance does not reduce uniqueness or internal
 diversity beyond 5% absolute.
 
-All claims are conditional on grammar G and primitives P used for AI
-computation (declared in docs/01_grammar.md).
+All claims are conditional on the explicit molecular grammar G and primitive set P defined in docs/01_grammar.md; changing them would modify the objective.
 


### PR DESCRIPTION
## Summary
- Define primitive set and production rules for molecular grammar G in docs/01_grammar.md
- Clarify all claims in docs/00_objectives.md are conditioned on the explicit grammar and primitives

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689739ea59d08325aaf11f1e95f2e198