### PR TITLE
Enable RDKit metrics and record run config

### DIFF
--- a/assembly_diffusion/eval/metrics_writer.py
+++ b/assembly_diffusion/eval/metrics_writer.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-SCHEMA_VERSION = "1.0"
+SCHEMA_VERSION = "1.1"
 
 
 def write_metrics(outdir: str, **metrics: Any) -> None:
@@ -33,10 +33,11 @@ def write_metrics(outdir: str, **metrics: Any) -> None:
 
     payload: dict[str, Any] = {"schema_version": SCHEMA_VERSION}
     for key, value in metrics.items():
-        # Cast basic numeric types to float for consistency.  Complex structures
-        # such as CI lists are emitted unchanged.
-        if isinstance(value, (int, float)):
+        # Preserve ints (e.g., random seeds) while normalising floats.
+        if isinstance(value, float):
             payload[key] = float(value)
+        elif isinstance(value, int):
+            payload[key] = int(value)
         else:
             payload[key] = value
 

--- a/assembly_diffusion/pipeline.py
+++ b/assembly_diffusion/pipeline.py
@@ -11,7 +11,7 @@ import numpy as np
 # Try RDKit early to fail fast when metrics require it
 try:
     from rdkit import Chem, DataStructs
-    from rdkit.Chem import AllChem
+    from rdkit.Chem import AllChem, QED, rdMolDescriptors
 
     _HAVE_RDKIT = True
 except Exception:
@@ -146,6 +146,34 @@ def _novelty(
     nov = [s for s in valid_canonical if s and s not in ref_set]
     denom = len([s for s in valid_canonical if s])
     return float(len(nov)) / float(denom) if denom > 0 else 0.0
+
+
+def _qed_sa(valid_smiles: List[str]) -> Tuple[float, float]:
+    """Average QED and a simple SA proxy for ``valid_smiles``."""
+    if not valid_smiles:
+        return 0.0, 0.0
+    qed_scores: List[float] = []
+    sa_scores: List[float] = []
+    for s in valid_smiles:
+        mol = Chem.MolFromSmiles(s)
+        if not mol:
+            continue
+        try:
+            qed_scores.append(float(QED.qed(mol)))
+        except Exception:
+            pass
+        try:
+            sa = (
+                rdMolDescriptors.CalcNumRotatableBonds(mol)
+                + rdMolDescriptors.CalcNumBridgeheadAtoms(mol)
+                + rdMolDescriptors.CalcNumSpiroAtoms(mol)
+            )
+            sa_scores.append(float(sa))
+        except Exception:
+            pass
+    qed = sum(qed_scores) / len(qed_scores) if qed_scores else 0.0
+    sa = sum(sa_scores) / len(sa_scores) if sa_scores else 0.0
+    return qed, sa
 
 
 def _median(values: List[float]) -> float:
@@ -332,6 +360,8 @@ def run_pipeline(
         "uniqueness": False,
         "diversity": False,
         "novelty": False,
+        "qed": False,
+        "sa": False,
     }
 
     if cfg.get("metrics", {}).get("rdkit", True) and _HAVE_RDKIT:
@@ -355,6 +385,8 @@ def run_pipeline(
             split=cfg["dataset"]["split"],
             limit=int(cfg["dataset"].get("limit", 0) or 0),
         )
+
+        qed, sa = _qed_sa(valid_smiles)
     elif not _HAVE_RDKIT and cfg.get("metrics", {}).get("rdkit", True):
         canonical, valid_mask = smiles, [False] * len(smiles)
         valid_fraction = (
@@ -363,6 +395,8 @@ def run_pipeline(
         uniqueness = 0.0
         diversity = 0.0
         novelty = 0.0
+        qed = 0.0
+        sa = 0.0
         for k in flags:
             flags[k] = True
     else:
@@ -371,6 +405,8 @@ def run_pipeline(
         uniqueness = 0.0
         diversity = 0.0
         novelty = 0.0
+        qed = 0.0
+        sa = 0.0
 
     # 4) Assembly index scoring and median
     median_ai = 0.0
@@ -428,6 +464,10 @@ def run_pipeline(
         "diversity_ci": _ci_placeholder(diversity),
         "novelty": float(novelty),
         "novelty_ci": _ci_placeholder(novelty),
+        "qed": float(qed),
+        "qed_ci": _ci_placeholder(qed),
+        "sa": float(sa),
+        "sa_ci": _ci_placeholder(sa),
         "median_ai": float(median_ai),
         "median_ai_ci": _ci_placeholder(median_ai),
     }

--- a/configs/registry.yaml
+++ b/configs/registry.yaml
@@ -6,7 +6,7 @@ experiments:
     model: {ckpt: null, steps: 5, guidance: {enabled: false, weight: 0.0, policy: additive}}
     ai: {scorer: surrogate, surrogate_ckpt: dummy, grammar: default, calibration: {n_mols: 0}}
     sampler: {n_samples: 10, batch_size: 4}
-    metrics: {rdkit: false, novelty: false, uniqueness: false, diversity: internal_tanimoto}
+    metrics: {rdkit: true, novelty: true, uniqueness: true, diversity: internal_tanimoto}
     artifacts: {save_smiles: true, save_sdf: false, save_ai_scores: true}
 
   exp02_guided_lambda1:
@@ -16,7 +16,7 @@ experiments:
     model: {ckpt: null, steps: 5, guidance: {enabled: true, weight: 1.0, policy: additive}}
     ai: {scorer: surrogate, surrogate_ckpt: dummy, grammar: default, calibration: {n_mols: 0}}
     sampler: {n_samples: 10, batch_size: 4}
-    metrics: {rdkit: false, novelty: false, uniqueness: false, diversity: internal_tanimoto}
+    metrics: {rdkit: true, novelty: true, uniqueness: true, diversity: internal_tanimoto}
     artifacts: {save_smiles: true, save_sdf: false, save_ai_scores: true}
 
   exp03_guided_lambda0p5:
@@ -26,7 +26,7 @@ experiments:
     model: {ckpt: null, steps: 5, guidance: {enabled: true, weight: 0.5, policy: additive}}
     ai: {scorer: surrogate, surrogate_ckpt: dummy, grammar: default, calibration: {n_mols: 0}}
     sampler: {n_samples: 10, batch_size: 4}
-    metrics: {rdkit: false, novelty: false, uniqueness: false, diversity: internal_tanimoto}
+    metrics: {rdkit: true, novelty: true, uniqueness: true, diversity: internal_tanimoto}
     artifacts: {save_smiles: true, save_sdf: false, save_ai_scores: true}
 
   exp04_guided_lambda2:
@@ -36,7 +36,7 @@ experiments:
     model: {ckpt: null, steps: 5, guidance: {enabled: true, weight: 2.0, policy: additive}}
     ai: {scorer: surrogate, surrogate_ckpt: dummy, grammar: default, calibration: {n_mols: 0}}
     sampler: {n_samples: 10, batch_size: 4}
-    metrics: {rdkit: false, novelty: false, uniqueness: false, diversity: internal_tanimoto}
+    metrics: {rdkit: true, novelty: true, uniqueness: true, diversity: internal_tanimoto}
     artifacts: {save_smiles: true, save_sdf: false, save_ai_scores: true}
 
   exp05_permuted_ai_control:
@@ -46,7 +46,7 @@ experiments:
     model: {ckpt: null, steps: 5, guidance: {enabled: true, weight: 1.0, policy: additive}}
     ai: {scorer: surrogate, surrogate_ckpt: dummy, grammar: default, mode: permuted, calibration: {n_mols: 0}}
     sampler: {n_samples: 10, batch_size: 4}
-    metrics: {rdkit: false, novelty: false, uniqueness: false, diversity: internal_tanimoto}
+    metrics: {rdkit: true, novelty: true, uniqueness: true, diversity: internal_tanimoto}
     artifacts: {save_smiles: true, save_sdf: false, save_ai_scores: true}
 
   exp06_null_ai_control:
@@ -56,5 +56,5 @@ experiments:
     model: {ckpt: null, steps: 5, guidance: {enabled: true, weight: 1.0, policy: additive}}
     ai: {scorer: surrogate, surrogate_ckpt: dummy, grammar: default, mode: null, calibration: {n_mols: 0}}
     sampler: {n_samples: 10, batch_size: 4}
-    metrics: {rdkit: false, novelty: false, uniqueness: false, diversity: internal_tanimoto}
+    metrics: {rdkit: true, novelty: true, uniqueness: true, diversity: internal_tanimoto}
     artifacts: {save_smiles: true, save_sdf: false, save_ai_scores: true}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@ numpy
 pandas
 scipy
 statsmodels
-rdkit-pypi; python_version < "3.12"
-# RDKit is optional and often easier to install via conda:
-# conda install -c conda-forge rdkit
+rdkit
 
 networkx

--- a/scripts/experiment.py
+++ b/scripts/experiment.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
 
     # run the pipeline and always write metrics.json
     metrics, flags = run_pipeline(cfg, outdir)
-    write_metrics(outdir, **metrics)
+    write_metrics(outdir, seed=int(cfg["seed"]), config=cfg, **metrics)
 
     _manifest(outdir, cfg, extra={"run_id": run_id, "requires_confirmation": flags})
     print(f"[OK] Wrote manifest and artifacts to {outdir}")

--- a/tests/test_pipeline_smoke.py
+++ b/tests/test_pipeline_smoke.py
@@ -11,7 +11,18 @@ def test_pipeline_runs():
     assert len(results) >= 2
     for run_dir in results[-2:]:
         m = json.load(open(run_dir / "metrics.json"))
-        for k in ["valid_fraction", "uniqueness", "diversity", "novelty", "median_ai"]:
+        for k in [
+            "valid_fraction",
+            "uniqueness",
+            "diversity",
+            "novelty",
+            "qed",
+            "sa",
+            "median_ai",
+            "seed",
+            "config",
+            "schema_version",
+        ]:
             assert k in m
         # calibration curve should be present
         cal_path = run_dir / "ai_calibration.csv"


### PR DESCRIPTION
## Summary
- compute QED, SA, and diversity using RDKit
- record run seed and config in metrics.json with schema version 1.1
- enable RDKit metrics in experiment registry

## Testing
- `pytest tests/test_pipeline_smoke.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas'; ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68973da8b7188325bbd97710f555476d