### PR TITLE
Add SE(3) guidance path with 3D-aware coordinates

### DIFF
--- a/assembly_diffusion/__init__.py
+++ b/assembly_diffusion/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "policy",
     "sampler",
     "guidance",
+    "se3_guidance",
     "data",
     "train",
     "config",

--- a/assembly_diffusion/se3_guidance.py
+++ b/assembly_diffusion/se3_guidance.py
@@ -1,0 +1,79 @@
+import torch
+from torch import Tensor
+from typing import Optional
+
+from .guidance import AssemblyPrior
+
+
+class DummySE3Flow(torch.nn.Module):
+    """Minimal SE(3)-equivariant-like flow operating on 3D coordinates.
+
+    The flow simply maps distances from the origin to logits, serving as a
+    placeholder for a real equivariant model."""
+
+    def forward(self, coords: Tensor, t: int, mask: Optional[Tensor] = None) -> Tensor:
+        # ``coords`` is expected to be ``(N, 3)``.  We use the negative radius as
+        # a simple score, higher for atoms near the origin.
+        logits = -torch.linalg.norm(coords, dim=-1)
+        if mask is not None and mask.shape[0] != logits.shape[0]:
+            logits = logits[: mask.shape[0]]
+        return logits
+
+
+class GeometryPrior(torch.nn.Module):
+    """Very small geometric prior encouraging compact structures."""
+
+    def forward(self, coords: Tensor) -> Tensor:
+        # Penalise atoms further than unit distance from the origin.
+        dist = torch.linalg.norm(coords, dim=-1)
+        return -torch.clamp(dist - 1.0, min=0.0)
+
+
+class SE3Guidance:
+    """Plug-in guidance combining geometry priors and assembly heuristics."""
+
+    def __init__(
+        self,
+        flow: torch.nn.Module,
+        assembly_prior: Optional[AssemblyPrior] = None,
+        geometry_prior: Optional[torch.nn.Module] = None,
+    ) -> None:
+        self.flow = flow
+        self.assembly_prior = assembly_prior
+        self.geometry_prior = geometry_prior
+
+    def __call__(self, logits: Tensor, graph, t: int, mask: Tensor) -> Tensor:
+        """Return guidance ``ΔS`` for non-STOP actions.
+
+        The method computes logits from the ``flow`` based on the graph's 3D
+        coordinates and contrasts them with the provided ``logits``.  Optionally
+        ``assembly_prior`` and ``geometry_prior`` are applied and the resulting
+        adjustment is returned for use with :func:`reweight`.
+        """
+
+        coords = getattr(graph, "coords", None)
+        if coords is None:
+            raise ValueError("SE3Guidance requires graphs with 3D coordinates")
+
+        flow_logits = self.flow(coords, t, mask)
+        flow_logits = flow_logits.to(logits.device)
+        # Ensure alignment with non-STOP logits
+        target_len = logits.shape[0] - 1
+        if flow_logits.shape[0] < target_len:
+            flow_logits = torch.nn.functional.pad(flow_logits, (0, target_len - flow_logits.shape[0]))
+        elif flow_logits.shape[0] > target_len:
+            flow_logits = flow_logits[:target_len]
+
+        delta = flow_logits - logits[:-1]
+
+        if self.geometry_prior is not None:
+            delta = delta + self.geometry_prior(coords)
+
+        if self.assembly_prior is not None:
+            temp = self.assembly_prior.reweight(logits.clone(), graph)
+            delta = delta + (temp[:-1] - logits[:-1])
+
+        return delta
+
+
+__all__ = ["DummySE3Flow", "GeometryPrior", "SE3Guidance"]

--- a/tests/test_se3_guidance.py
+++ b/tests/test_se3_guidance.py
@@ -1,0 +1,37 @@
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from assembly_diffusion.graph import MoleculeGraph
+from assembly_diffusion.guidance import AssemblyPrior
+from assembly_diffusion.se3_guidance import DummySE3Flow, GeometryPrior, SE3Guidance
+
+
+def make_graph():
+    atoms = ["C", "C"]
+    bonds = torch.zeros((2, 2), dtype=torch.int64)
+    coords = torch.tensor([[0.0, 0.0, 0.0], [2.0, 0.0, 0.0]])
+    return MoleculeGraph(atoms, bonds, coords)
+
+
+def test_se3_guidance_ablation():
+    graph = make_graph()
+    logits = torch.zeros(3)  # two actions + STOP
+    mask = torch.ones(2, dtype=torch.bool)
+
+    flow = DummySE3Flow()
+    geom = GeometryPrior()
+    prior = AssemblyPrior(coeff=0.1)
+    base = SE3Guidance(flow)
+    g_only = SE3Guidance(flow, geometry_prior=geom)
+    a_only = SE3Guidance(flow, assembly_prior=prior)
+    both = SE3Guidance(flow, assembly_prior=prior, geometry_prior=geom)
+
+    d_base = base(logits, graph, 0, mask)
+    d_g = g_only(logits, graph, 0, mask) - d_base
+    d_a = a_only(logits, graph, 0, mask) - d_base
+    d_b = both(logits, graph, 0, mask)
+
+    # Combined guidance should equal the base flow adjustment plus individual
+    # geometry and assembly contributions.
+    assert torch.allclose(d_b, d_base + d_g + d_a)


### PR DESCRIPTION
## Summary
- allow MoleculeGraph to optionally store 3D coordinates
- implement SE3Guidance plugin with dummy SE(3)-equivariant flow and geometry prior
- add ablation test demonstrating assembly and geometry guidance contributions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68974218b6148325b2a311594d0d745b