### PR TITLE
Declare and enforce molecular grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ prints a canonical SMILES string of the generated molecule. Additional utilities
 for training and evaluation are available in the `assembly_diffusion` module and
 can serve as starting points for custom experiments.
 
+## Assumptions and Guarantees
+
+The codebase assumes a minimal molecular grammar governing which atoms,
+bond orders and valence configurations are permitted.  The full specification is
+documented in [docs/grammar.md](docs/grammar.md).
+
 ## Testing
 
 Run the test suite (if present) with:

--- a/assembly_diffusion/mask.py
+++ b/assembly_diffusion/mask.py
@@ -1,22 +1,48 @@
+"""Feasibility masking governed by the molecular grammar.
+
+The grammar is declared via :data:`GRAMMAR_SPEC` and enumerates the allowed
+atoms, bond orders and valence caps for neutral molecules.  See
+``docs/grammar.md`` for the full specification.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple, Union
+
 from .graph import MoleculeGraph, Chem, VALENCE_CAP, ALLOWED_ATOMS
 
 
-def valence_check(x: MoleculeGraph, i: int, j: int, b: int) -> bool:
-    """Return ``True`` if editing bond ``(i, j)`` to ``b`` respects valence.
+# ---------------------------------------------------------------------------
+# Grammar declaration -------------------------------------------------------
 
-    The check first enforces simple valence caps based on atom types. When
-    RDKit is available, a full molecule sanitization is performed for stricter
-    validation.  When RDKit is not installed, only the fast valence cap check
-    is used.
-    """
+#: Top level molecular grammar specification used throughout the project.
+#: The specification is intentionally small: only neutral C, N, O and H atoms
+#: are allowed and bond orders are limited to single, double and triple bonds.
+GRAMMAR_SPEC = {
+    "atoms": tuple(ALLOWED_ATOMS),
+    "bond_orders": (0, 1, 2, 3),
+    "max_valence": VALENCE_CAP,
+    "neutral_charge": True,
+    "assembly_step": (
+        "Edit an existing bond or attach a new atom with a single bond",
+    ),
+}
+
+
+EditTuple = Union[Tuple[int, int, int], Tuple[str, int, str], str]
+
+
+def valence_check(x: MoleculeGraph, i: int, j: int, b: int) -> bool:
+    """Return ``True`` if editing bond ``(i, j)`` to ``b`` respects valence."""
 
     current = int(x.bonds[i, j])
-    deg_i = int(x.bonds[i].sum().item()) - current + b
-    deg_j = int(x.bonds[j].sum().item()) - current + b
+    deg_i = x.degree(i) - current + b
+    deg_j = x.degree(j) - current + b
 
-    if deg_i > VALENCE_CAP.get(x.atoms[i], 4):
+    max_val = GRAMMAR_SPEC["max_valence"]
+    if deg_i > max_val.get(x.atoms[i], 4):
         return False
-    if deg_j > VALENCE_CAP.get(x.atoms[j], 4):
+    if deg_j > max_val.get(x.atoms[j], 4):
         return False
 
     if Chem is not None:
@@ -25,21 +51,116 @@ def valence_check(x: MoleculeGraph, i: int, j: int, b: int) -> bool:
     return True
 
 
+def enforce_grammar_strict(edit: EditTuple, g: MoleculeGraph) -> None:
+    """Raise ``AssertionError`` if ``edit`` violates :data:`GRAMMAR_SPEC`.
+
+    The error message includes the offending ``edit`` tuple to ease debugging.
+    """
+
+    if edit == "STOP":
+        return
+
+    if isinstance(edit, tuple) and edit and edit[0] == "ADD":
+        _, i, atom = edit
+        if atom not in GRAMMAR_SPEC["atoms"]:
+            raise AssertionError(f"GRAMMAR violation for edit {edit}: unknown atom")
+        if not (0 <= i < len(g.atoms)):
+            raise AssertionError(f"GRAMMAR violation for edit {edit}: bad index")
+        if g.free_valence(i) <= 0:
+            raise AssertionError(f"GRAMMAR violation for edit {edit}: no valence")
+        return
+
+    # Bond edit
+    i, j, b = edit  # type: ignore[misc]
+    n = len(g.atoms)
+    if not (0 <= i < n and 0 <= j < n and i < j):
+        raise AssertionError(f"GRAMMAR violation for edit {edit}: bad indices")
+    if b not in GRAMMAR_SPEC["bond_orders"]:
+        raise AssertionError(
+            f"GRAMMAR violation for edit {edit}: illegal bond order",
+        )
+
+
+def build_feasibility_mask(g: MoleculeGraph) -> Dict[EditTuple, int]:
+    """Return a feasibility mask of edits consistent with :data:`GRAMMAR_SPEC`.
+
+    The returned dictionary has keys describing edit tuples and values ``1`` for
+    legal edits and ``0`` for illegal ones.  Bond edits are enumerated for all
+    pairs ``(i, j)`` with ``i < j`` and bond orders in the grammar.  Atom
+    insertions are included for all sites with free valence.
+    """
+
+    # Validate the existing molecule against the grammar first
+    for idx, atom in enumerate(g.atoms):
+        if atom not in GRAMMAR_SPEC["atoms"]:
+            raise AssertionError(
+                f"GRAMMAR violation for edit ('ADD', {idx}, '{atom}')",
+            )
+        cap = GRAMMAR_SPEC["max_valence"][atom]
+        if g.degree(idx) > cap:
+            raise AssertionError(
+                f"GRAMMAR violation for edit {(idx, None, None)}: degree exceeds cap",
+            )
+    n = len(g.atoms)
+    for i in range(n):
+        for j in range(i + 1, n):
+            b = int(g.bonds[i, j])
+            if b not in GRAMMAR_SPEC["bond_orders"]:
+                raise AssertionError(
+                    f"GRAMMAR violation for edit {(i, j, b)}: bond order not allowed",
+                )
+
+    mask: Dict[EditTuple, int] = {}
+    for i in range(n):
+        for j in range(i + 1, n):
+            for b in GRAMMAR_SPEC["bond_orders"]:
+                edit = (i, j, b)
+                enforce_grammar_strict(edit, g)
+                mask[edit] = 1 if valence_check(g, i, j, b) else 0
+    for i in g.free_valence_sites():
+        for atom in GRAMMAR_SPEC["atoms"]:
+            edit = ("ADD", i, atom)
+            enforce_grammar_strict(edit, g)
+            mask[edit] = 1
+    mask["STOP"] = 1
+    assert_mask_equals_grammar(g, mask)
+    return mask
+
+
+def assert_mask_equals_grammar(g: MoleculeGraph, mask: Dict[EditTuple, int]) -> None:
+    """Assert that ``mask`` matches the grammar for molecule ``g`` exactly."""
+
+    expected: Dict[EditTuple, int] = {}
+    n = len(g.atoms)
+    for i in range(n):
+        for j in range(i + 1, n):
+            for b in GRAMMAR_SPEC["bond_orders"]:
+                expected[(i, j, b)] = 1 if valence_check(g, i, j, b) else 0
+    for i in g.free_valence_sites():
+        for atom in GRAMMAR_SPEC["atoms"]:
+            expected[("ADD", i, atom)] = 1
+    expected["STOP"] = 1
+
+    mask_keys = set(mask.keys())
+    expected_keys = set(expected.keys())
+    if mask_keys != expected_keys:
+        missing = expected_keys - mask_keys
+        extra = mask_keys - expected_keys
+        raise AssertionError(
+            f"Grammar mismatch: missing={missing}, extra={extra}",
+        )
+    for edit, exp in expected.items():
+        got = mask[edit]
+        if got != exp:
+            raise AssertionError(
+                f"Grammar mismatch for edit {edit}: mask={got}, expected={exp}",
+            )
+
+
+# Backwards compatibility ----------------------------------------------------
 class FeasibilityMask:
     """Compute feasibility masks over possible edit actions."""
 
     def mask_edits(self, x: MoleculeGraph):
-        mask = {}
-        # --- Bond edits -------------------------------------------------
-        for i in range(len(x.atoms)):
-            for j in range(i + 1, len(x.atoms)):
-                for b in [0, 1, 2, 3]:
-                    mask[(i, j, b)] = 1 if valence_check(x, i, j, b) else 0
+        return build_feasibility_mask(x)
 
-        # --- Atom insertions -------------------------------------------
-        for i in x.free_valence_sites():
-            for atom in ALLOWED_ATOMS:
-                mask[("ADD", i, atom)] = 1
-
-        mask["STOP"] = 1
-        return mask

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -1,0 +1,43 @@
+# Molecular Grammar
+
+The molecular diffusion model operates under a fixed grammar ``G`` describing
+which molecules can be constructed and what edits are considered legal.
+
+## Allowed atoms
+
+Only neutral atoms of the following types are permitted:
+
+| Atom | Maximum valence |
+| ---- | --------------- |
+| C    | 4 |
+| N    | 3 |
+| O    | 2 |
+| H    | 1 |
+
+## Bond orders
+
+Bond orders are restricted to ``0`` (remove bond) and ``1``–``3`` for single,
+double and triple bonds respectively.
+
+## Charge state
+
+All molecules are assumed to be neutral.  The grammar does not model explicit
+charges and any edit resulting in a charged species is considered illegal.
+
+## Assembly step
+
+One *assembly step* performs exactly one of the following operations:
+
+1. **Bond edit** – set the bond order ``b`` between two existing atoms ``i`` and
+   ``j`` (with ``i < j``) to ``b`` in ``{0, 1, 2, 3}``.
+2. **Atom insertion** – attach a new atom from the allowed set to an existing
+   atom using a single bond.
+3. **STOP** – terminate the assembly process.
+
+An edit is *legal* if it respects the atom set, bond order limits and the
+valence caps listed above.  Attempts to exceed valence or use unsupported bond
+orders are masked out by the feasibility mask.
+
+The helpers in ``assembly_diffusion.mask`` and ``assembly_diffusion.graph``
+enforce this specification.
+

--- a/tests/test_mask_grammar.py
+++ b/tests/test_mask_grammar.py
@@ -1,0 +1,52 @@
+import torch
+import pytest
+
+from assembly_diffusion.graph import MoleculeGraph
+from assembly_diffusion.mask import build_feasibility_mask
+
+
+@pytest.mark.parametrize(
+    "atoms,bonds,edit,expected",
+    [
+        # Tree growth within valence limits is legal
+        (
+            ["C", "H", "H", "H"],
+            [
+                [0, 1, 1, 1],
+                [1, 0, 0, 0],
+                [1, 0, 0, 0],
+                [1, 0, 0, 0],
+            ],
+            ("ADD", 0, "H"),
+            1,
+        ),
+        # Illegal bond orders are masked
+        (
+            ["O", "O"],
+            [
+                [0, 0],
+                [0, 0],
+            ],
+            (0, 1, 3),
+            0,
+        ),
+        # Over-valent edits are masked
+        (
+            ["C", "H", "H", "H", "H"],
+            [
+                [0, 1, 1, 1, 1],
+                [1, 0, 0, 0, 0],
+                [1, 0, 0, 0, 0],
+                [1, 0, 0, 0, 0],
+                [1, 0, 0, 0, 0],
+            ],
+            (0, 1, 2),
+            0,
+        ),
+    ],
+)
+def test_mask_grammar(atoms, bonds, edit, expected):
+    g = MoleculeGraph(atoms, torch.tensor(bonds, dtype=torch.int64))
+    mask = build_feasibility_mask(g)
+    assert mask.get(edit, 0) == expected
+


### PR DESCRIPTION
## Summary
- Define explicit molecular grammar and feasibility mask enforcing it
- Add edit legality helpers and grammar docs
- Test grammar masking and update README assumptions

## Testing
- `ruff check .` *(fails: 45 errors)*
- `ruff check assembly_diffusion/mask.py assembly_diffusion/graph.py tests/test_mask_grammar.py`
- `mypy assembly_diffusion` *(fails: 82 errors)*
- `pytest -q tests/test_mask_grammar.py`


------
https://chatgpt.com/codex/tasks/task_e_68974d3c63d88325b6859d0b1a978dcc