### PR TITLE
refactor: replace broad exception handlers

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -19,7 +19,7 @@ from statsmodels.genmod.cov_struct import Exchangeable
 try:  # RDKit is optional and may not be installed in every environment.
     from rdkit import Chem
     from rdkit.Chem.Scaffolds import MurckoScaffold
-except Exception:  # pragma: no cover - exercised only when RDKit is missing
+except ImportError:  # pragma: no cover - exercised only when RDKit is missing
     Chem = None
     MurckoScaffold = None
 

--- a/assembly_diffusion/data.py
+++ b/assembly_diffusion/data.py
@@ -2,6 +2,7 @@ import hashlib
 import os
 import tarfile
 import urllib.request
+import urllib.error
 import hashlib
 import logging
 
@@ -52,7 +53,7 @@ def download_qm9(
         logger.info("Downloading QM9 dataset.")
         try:
             urllib.request.urlretrieve(url, archive_path)
-        except Exception as e:  # pragma: no cover - network failure
+        except (urllib.error.URLError, OSError) as e:  # pragma: no cover - network failure
             raise RuntimeError(f"Failed to download QM9 dataset: {e}") from e
         if not _verify_sha256(archive_path, sha256):
             raise RuntimeError("Checksum mismatch for downloaded QM9 archive.")

--- a/assembly_diffusion/eval/metrics.py
+++ b/assembly_diffusion/eval/metrics.py
@@ -66,7 +66,7 @@ def _qed_sa(smiles: List[str]) -> Tuple[float, float]:
             continue
         try:
             qeds.append(float(QED.qed(mol)))
-        except Exception:
+        except (ValueError, RuntimeError):
             pass
         try:
             sa = (
@@ -75,7 +75,7 @@ def _qed_sa(smiles: List[str]) -> Tuple[float, float]:
                 + rdMolDescriptors.CalcNumSpiroAtoms(mol)
             )
             sas.append(float(sa))
-        except Exception:
+        except (ValueError, RuntimeError):
             pass
     qed = sum(qeds) / len(qeds) if qeds else 0.0
     sa = sum(sas) / len(sas) if sas else 0.0

--- a/assembly_diffusion/eval/validity.py
+++ b/assembly_diffusion/eval/validity.py
@@ -22,7 +22,7 @@ def sanitize_or_none(graph: MoleculeGraph):
 
     try:
         return graph.to_rdkit()
-    except Exception:
+    except (ValueError, RuntimeError):
         return None
 
 

--- a/assembly_diffusion/graph.py
+++ b/assembly_diffusion/graph.py
@@ -149,7 +149,7 @@ class MoleculeGraph:
                 [list(conf.GetAtomPosition(i)) for i in range(n)],
                 dtype=torch.float32,
             )
-        except Exception:
+        except (ValueError, RuntimeError):
             pass
         return MoleculeGraph(atoms, bonds, coords)
 
@@ -199,7 +199,7 @@ class MoleculeGraph:
         try:
             self.to_rdkit()
             return True
-        except Exception:
+        except (ValueError, RuntimeError):
             return False
 
     def apply_edit(self, i: int, j: int, b: int | None) -> "MoleculeGraph":

--- a/assembly_diffusion/monitor.py
+++ b/assembly_diffusion/monitor.py
@@ -16,14 +16,14 @@ logger = logging.getLogger(__name__)
 
 try:
     from torch.utils.tensorboard import SummaryWriter
-except Exception:
+except ImportError:
     SummaryWriter = None
 
 # Optional resource monitoring dependencies.  These are best-effort and the
 # monitor will operate without them if unavailable.
 try:
     import psutil  # type: ignore
-except Exception:  # pragma: no cover - dependency not installed
+except ImportError:  # pragma: no cover - dependency not installed
     psutil = None  # type: ignore
 
 try:
@@ -31,9 +31,9 @@ try:
 
     try:
         pynvml.nvmlInit()
-    except Exception:  # pragma: no cover - GPU may be absent
+    except pynvml.NVMLError:  # pragma: no cover - GPU may be absent
         pynvml = None  # type: ignore
-except Exception:  # pragma: no cover - dependency not installed
+except ImportError:  # pragma: no cover - dependency not installed
     pynvml = None  # type: ignore
 
 
@@ -52,7 +52,7 @@ def _git_hash() -> str:
             .decode()
             .strip()
         )
-    except Exception:
+    except (subprocess.CalledProcessError, OSError):
         return "unknown"
 
 
@@ -100,13 +100,13 @@ class RunMonitor:
         try:
             with open(os.path.join(run_dir, "run_metadata.json"), "w") as f:
                 json.dump({"git_hash": self._git_hash, "config": self._config}, f)
-        except Exception as e:
+        except OSError as e:
             self._log_error_once("metadata write failed", e)
         self.tb = None
         if use_tb and SummaryWriter:
             try:
                 self.tb = SummaryWriter(run_dir)
-            except Exception as e:
+            except (OSError, RuntimeError) as e:
                 self._log_error_once("TensorBoard init failed", e)
         # Dedicated heartbeat thread for liveness reporting.
         self._hb_thread = threading.Thread(
@@ -129,7 +129,7 @@ class RunMonitor:
         try:
             signal.signal(signal.SIGUSR1, self._sig_dump)
             signal.signal(signal.SIGUSR2, self._sig_ckpt_req)
-        except Exception:
+        except (AttributeError, OSError, ValueError):
             pass
 
     def close(self) -> None:
@@ -141,13 +141,13 @@ class RunMonitor:
             try:
                 self.tb.flush()
                 self.tb.close()
-            except Exception:
+            except OSError:
                 pass
         # Gracefully shut down NVML if it was initialized.
         if pynvml:
             try:  # pragma: no cover - GPU-specific
                 pynvml.nvmlShutdown()
-            except Exception:
+            except pynvml.NVMLError:
                 pass
 
     # Public API
@@ -175,7 +175,7 @@ class RunMonitor:
         if self.tb:
             try:
                 self.tb.add_scalar(name, value, step)
-            except Exception as e:
+            except (RuntimeError, OSError) as e:
                 self._log_error_once("TensorBoard add_scalar failed", e)
 
     def sample_smiles(self, smiles: list[str], step: int) -> None:
@@ -187,7 +187,7 @@ class RunMonitor:
                 f.write("# config: " + json.dumps(self._config) + "\n")
                 for s in smiles:
                     f.write(s + "\n")
-        except Exception as e:
+        except OSError as e:
             self._log_error_once("sample_smiles write failed", e)
 
     def resources(
@@ -223,7 +223,7 @@ class RunMonitor:
             meta_path = path + ".meta.json"
             with open(meta_path, "w") as mf:
                 json.dump({"git_hash": self._git_hash, "config": self._config}, mf)
-        except Exception as e:
+        except OSError as e:
             self._log_error_once("checkpoint metadata failed", e)
         self._event(
             "checkpoint",
@@ -247,14 +247,14 @@ class RunMonitor:
         if ckpt_req:
             try:
                 os.remove(self._ckpt_sentinel)
-            except Exception:
+            except OSError:
                 pass
             self._sig_ckpt_req()
 
         if dump_req:
             try:
                 os.remove(self._dump_sentinel)
-            except Exception:
+            except OSError:
                 pass
             self._sig_dump()
 
@@ -269,12 +269,9 @@ class RunMonitor:
         try:
             with open(err_path, "a") as ef:
                 ef.write(err + "\n")
-        except Exception:
+        except OSError:
             pass
-        try:
-            logger.error(err)
-        except Exception:
-            pass
+        logger.error(err)
         self._error_logged = True
 
     def _roll_existing_jsonl(self, today: str) -> None:
@@ -290,7 +287,7 @@ class RunMonitor:
         if os.path.islink(self.jsonl_path):
             try:
                 os.unlink(self.jsonl_path)
-            except Exception:
+            except OSError:
                 pass
             return
         try:
@@ -298,7 +295,7 @@ class RunMonitor:
             file_day = mtime.strftime("%Y%m%d")
             rolled = os.path.join(self.run_dir, f"events-{file_day}.jsonl")
             os.replace(self.jsonl_path, rolled)
-        except Exception as e:
+        except OSError as e:
             self._log_error_once("event log rotation failed", e)
 
     def _open_log_file(self, day: str):
@@ -306,7 +303,7 @@ class RunMonitor:
         path = os.path.join(self.run_dir, f"events-{day}.jsonl")
         try:
             f = open(path, "a", buffering=1)
-        except Exception as e:
+        except OSError as e:
             self._log_error_once("event writer failed to open", e)
             return None
         try:
@@ -317,11 +314,11 @@ class RunMonitor:
                 pass
             os.symlink(os.path.basename(path), tmp_link)
             os.replace(tmp_link, self.jsonl_path)
-        except Exception:
+        except OSError:
             try:
                 if os.path.islink(tmp_link):
                     os.unlink(tmp_link)
-            except Exception:
+            except OSError:
                 pass
             # Best effort; if symlinks are unsupported fall back to using the
             # plain filename.
@@ -330,7 +327,7 @@ class RunMonitor:
                 path = self.jsonl_path
                 f.close()
                 f = open(path, "a", buffering=1)
-            except Exception as e:
+            except OSError as e:
                 self._log_error_once("event writer failed to open", e)
                 return None
         return f
@@ -370,7 +367,7 @@ class RunMonitor:
             if today != current_day:
                 try:
                     f.close()
-                except Exception:
+                except OSError:
                     pass
                 current_day = today
                 f = self._open_log_file(current_day)
@@ -382,11 +379,11 @@ class RunMonitor:
                 continue
             try:
                 f.write(json.dumps(evt) + "\n")
-            except Exception as e:
+            except OSError as e:
                 self._log_error_once("event write failed", e)
         try:
             f.close()
-        except Exception:
+        except OSError:
             pass
 
     def _write_heartbeat(self) -> None:
@@ -401,7 +398,7 @@ class RunMonitor:
         try:
             with open(self.heartbeat_path, "w") as f:
                 json.dump(hb, f)
-        except Exception as e:
+        except OSError as e:
             self._log_error_once("heartbeat write failed", e)
 
     def _heartbeat_loop(self) -> None:
@@ -422,7 +419,7 @@ class RunMonitor:
                 mem = pynvml.nvmlDeviceGetMemoryInfo(dev)
                 gpu_util = float(util.gpu)
                 vram = float(mem.used / 1e9)
-            except Exception:
+            except pynvml.NVMLError:
                 pass
         return cpu, ram, vram, gpu_util
 

--- a/assembly_diffusion/qm9_ai.py
+++ b/assembly_diffusion/qm9_ai.py
@@ -42,7 +42,7 @@ def generate_qm9_chon_ai(
 
     try:
         dataset = load_qm9_chon(max_heavy=max_heavy, data_dir=data_dir)
-    except Exception:  # pragma: no cover - dependency missing
+    except (ImportError, OSError, RuntimeError):  # pragma: no cover - dependency missing
         dataset = []
 
     surrogate = AISurrogate()
@@ -55,7 +55,7 @@ def generate_qm9_chon_ai(
             smiles = Chem.MolToSmiles(mol, canonical=True)
             scaffold = MurckoScaffold.MurckoScaffoldSmiles(mol)
             desc = _descriptor_vec(mol)
-        except Exception:
+        except (ValueError, RuntimeError):
             smiles = "".join(graph.atoms)
             scaffold = "NA"
             desc = [0.0] * 6

--- a/assembly_diffusion/train.py
+++ b/assembly_diffusion/train.py
@@ -120,13 +120,13 @@ def train_epoch(
         if monitor and (step_in_epoch % 50 == 0):
             try:
                 monitor.scalar("loss/train", float(batch_loss.detach().cpu()), step=step_in_epoch)
-            except Exception:
+            except (RuntimeError, OSError):
                 pass
         if monitor and (step_in_epoch % 100 == 0):
             try:
                 smi = xt_graphs[0].canonical_smiles()
                 monitor.sample_smiles([smi], step=step_in_epoch)
-            except Exception:
+            except (ValueError, RuntimeError):
                 pass
 
         if monitor and (time.time() - last_poke_check) > 5:

--- a/check_integrity.py
+++ b/check_integrity.py
@@ -30,7 +30,7 @@ def main() -> None:
             .decode("utf-8")
             .strip()
         )
-    except Exception as exc:
+    except (subprocess.CalledProcessError, OSError) as exc:
         logger.error("Unable to determine git commit: %s", exc)
         raise SystemExit(1)
 
@@ -38,7 +38,7 @@ def main() -> None:
     for path in glob.glob(os.path.join("checkpoints", "*.pt")):
         try:
             data = torch.load(path, map_location="cpu")
-        except Exception as exc:  # pragma: no cover - best effort load
+        except (OSError, RuntimeError) as exc:  # pragma: no cover - best effort load
             logger.error("Failed to load %s: %s", path, exc)
             ok = False
             continue

--- a/sample.py
+++ b/sample.py
@@ -49,7 +49,7 @@ def main():
             x = sampler.sample(kernel.T, x_init, guidance=guide, gamma=1.0)
             try:
                 smiles = x.canonical_smiles()
-            except Exception:
+            except (ValueError, RuntimeError):
                 smiles = None
             records.append(
                 {

--- a/scripts/analyze_calibrators.py
+++ b/scripts/analyze_calibrators.py
@@ -41,7 +41,7 @@ def bootstrap_ci(df: pd.DataFrame, alpha: float = 0.05, B: int = 1000) -> Tuple[
         try:
             m, c, r2 = fit_logfreq_vs_A(resampled)
             m_vals.append(m)
-        except Exception:
+        except (ValueError, RuntimeError):
             continue
     m_vals = np.array(m_vals)
     lo = np.quantile(m_vals, alpha/2)

--- a/scripts/experiment.py
+++ b/scripts/experiment.py
@@ -30,7 +30,7 @@ def _git_hash():
             .decode()
             .strip()
         )
-    except Exception:
+    except (subprocess.CalledProcessError, OSError):
         return "unknown"
 
 
@@ -41,7 +41,7 @@ def _pip_freeze():
             .decode()
             .splitlines()
         )
-    except Exception:
+    except (subprocess.CalledProcessError, OSError):
         return []
 
 
@@ -66,7 +66,7 @@ if __name__ == "__main__":
 
     try:
         import torch
-    except Exception:
+    except ImportError:
         torch = None
 
     from assembly_diffusion.eval.metrics_writer import write_metrics


### PR DESCRIPTION
## Summary
- narrow generic exception handling across modules
- add targeted imports for optional dependencies
- propagate file and subprocess errors with context

## Testing
- `pytest` *(fails: ImportError: RDKit is required for converting MoleculeGraph)*

------
https://chatgpt.com/codex/tasks/task_e_6897648d0b3083259a70b610777bcc6f