### PR TITLE
Centralize logging configuration

### DIFF
--- a/assembly_diffusion/cli.py
+++ b/assembly_diffusion/cli.py
@@ -1,13 +1,12 @@
 import argparse
 from typing import List, Tuple
 
-import argparse
-import logging
 import torch
 
 from .config import SamplingConfig
+from .logging_config import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class PolicyGrammarAdapter:

--- a/assembly_diffusion/data.py
+++ b/assembly_diffusion/data.py
@@ -2,8 +2,6 @@ import hashlib
 import os
 import tarfile
 import urllib.request
-import hashlib
-import logging
 
 import torch
 from torch.nn.utils.rnn import pad_sequence
@@ -11,8 +9,9 @@ from torch.utils.data import DataLoader, Dataset
 
 from .graph import MoleculeGraph
 from .backbone import ATOM_MAP
+from .logging_config import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 URL = "https://deepchemdata.s3-us-west-1.amazonaws.com/datasets/gdb9.tar.gz"
 QM9_SHA256 = "45255048ac6d83ea4b923ecdf7d6fb6dc62bfec5e80fbc5bcfd93a62157a31db"

--- a/assembly_diffusion/logging_config.py
+++ b/assembly_diffusion/logging_config.py
@@ -1,0 +1,23 @@
+import logging
+import os
+
+_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a module-level logger configured for console output.
+
+    The logger uses a :class:`~logging.StreamHandler` with a timestamped format
+    and honours the ``LOG_LEVEL`` environment variable to control verbosity.
+    Subsequent calls with the same ``name`` return the existing logger without
+    adding duplicate handlers.
+    """
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter(_LOG_FORMAT))
+        logger.addHandler(handler)
+    level_name = os.getenv("LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    logger.setLevel(level)
+    return logger

--- a/assembly_diffusion/monitor.py
+++ b/assembly_diffusion/monitor.py
@@ -10,9 +10,10 @@ import subprocess
 from pathlib import Path
 from datetime import datetime
 from typing import Optional
-import logging
 
-logger = logging.getLogger(__name__)
+from .logging_config import get_logger
+
+logger = get_logger(__name__)
 
 try:
     from torch.utils.tensorboard import SummaryWriter

--- a/assembly_diffusion/pipeline.py
+++ b/assembly_diffusion/pipeline.py
@@ -7,7 +7,8 @@ from pathlib import Path
 from typing import Iterable, List, Tuple, Optional, Dict, Any
 
 import numpy as np
-import logging
+
+from .logging_config import get_logger
 
 # Try RDKit early to fail fast when metrics require it
 try:
@@ -44,7 +45,7 @@ except Exception:
     AssemblyMC = None
     MoleculeGraph = None
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def _require_rdkit(cfg: Dict[str, Any]) -> None:

--- a/assembly_diffusion/train.py
+++ b/assembly_diffusion/train.py
@@ -1,6 +1,5 @@
 import os
 import random
-import logging
 import time
 from typing import Union
 
@@ -12,9 +11,10 @@ from .mask import FeasibilityMask
 from .graph import MoleculeGraph
 from .backbone import ATOM_TYPES
 from .monitor import RunMonitor
+from .logging_config import get_logger
 
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def teacher_edit(x0: MoleculeGraph, xt: MoleculeGraph) -> Union[str, tuple[int, int, int]]:


### PR DESCRIPTION
## Summary
- add `logging_config.get_logger` with timestamped stream handler and LOG_LEVEL env control
- switch core modules to use centralized `get_logger`

## Testing
- `rg -n "\bprint\s*\(" assembly_diffusion || true`
- `pytest -q tests/test_logging.py -q || true`


------
https://chatgpt.com/codex/tasks/task_e_6897de14ae408325a7762ba02a7c9024