### PR TITLE
refactor: narrow broad exceptions

### DIFF
--- a/assembly_diffusion/data.py
+++ b/assembly_diffusion/data.py
@@ -2,6 +2,7 @@ import hashlib
 import os
 import tarfile
 import urllib.request
+import urllib.error
 
 import torch
 from torch.nn.utils.rnn import pad_sequence
@@ -51,7 +52,7 @@ def download_qm9(
         logger.info("Downloading QM9 dataset.")
         try:
             urllib.request.urlretrieve(url, archive_path)
-        except Exception as e:  # pragma: no cover - network failure
+        except (urllib.error.URLError, OSError) as e:  # pragma: no cover - network failure
             raise RuntimeError(f"Failed to download QM9 dataset: {e}") from e
         if not _verify_sha256(archive_path, sha256):
             raise RuntimeError("Checksum mismatch for downloaded QM9 archive.")

--- a/assembly_diffusion/eval/metrics.py
+++ b/assembly_diffusion/eval/metrics.py
@@ -66,7 +66,7 @@ def _qed_sa(smiles: List[str]) -> Tuple[float, float]:
             continue
         try:
             qeds.append(float(QED.qed(mol)))
-        except Exception:
+        except (ValueError, RuntimeError):
             pass
         try:
             sa = (
@@ -75,7 +75,7 @@ def _qed_sa(smiles: List[str]) -> Tuple[float, float]:
                 + rdMolDescriptors.CalcNumSpiroAtoms(mol)
             )
             sas.append(float(sa))
-        except Exception:
+        except (ValueError, RuntimeError):
             pass
     qed = sum(qeds) / len(qeds) if qeds else 0.0
     sa = sum(sas) / len(sas) if sas else 0.0

--- a/assembly_diffusion/eval/validity.py
+++ b/assembly_diffusion/eval/validity.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 from ..graph import MoleculeGraph
 
+try:  # pragma: no cover - RDKit optional
+    from rdkit.Chem.rdchem import MolSanitizeException
+except ImportError:  # pragma: no cover - handled at runtime
+    MolSanitizeException = RuntimeError
 
 
 def sanitize_or_none(graph: MoleculeGraph):
@@ -22,7 +26,7 @@ def sanitize_or_none(graph: MoleculeGraph):
 
     try:
         return graph.to_rdkit()
-    except Exception:
+    except (ValueError, RuntimeError, MolSanitizeException):
         return None
 
 

--- a/assembly_diffusion/graph.py
+++ b/assembly_diffusion/graph.py
@@ -11,12 +11,14 @@ from typing import List, Optional
 import torch
 from torch import Tensor
 
-try:
+try:  # pragma: no cover - RDKit optional
     from rdkit import Chem
     from rdkit.Chem import SanitizeMol
+    from rdkit.Chem.rdchem import MolSanitizeException
 except ImportError:  # pragma: no cover - handled at runtime
     Chem = None
     SanitizeMol = None
+    MolSanitizeException = RuntimeError
 
 
 # Basic valence caps used for fast feasibility checks.  These constants are
@@ -149,7 +151,7 @@ class MoleculeGraph:
                 [list(conf.GetAtomPosition(i)) for i in range(n)],
                 dtype=torch.float32,
             )
-        except Exception:
+        except (ValueError, RuntimeError):
             pass
         return MoleculeGraph(atoms, bonds, coords)
 
@@ -199,7 +201,7 @@ class MoleculeGraph:
         try:
             self.to_rdkit()
             return True
-        except Exception:
+        except (ValueError, RuntimeError, MolSanitizeException):
             return False
 
     def apply_edit(self, i: int, j: int, b: int | None) -> "MoleculeGraph":

--- a/assembly_diffusion/qm9_ai.py
+++ b/assembly_diffusion/qm9_ai.py
@@ -9,11 +9,13 @@ try:  # pragma: no cover - optional rdkit dependency
     from rdkit import Chem
     from rdkit.Chem import Descriptors, rdMolDescriptors
     from rdkit.Chem.Scaffolds import MurckoScaffold
+    from rdkit.Chem.rdchem import MolSanitizeException
 except ImportError:  # pragma: no cover - handled at runtime
     Chem = None
     Descriptors = None
     rdMolDescriptors = None
     MurckoScaffold = None
+    MolSanitizeException = RuntimeError
 
 from .data import load_qm9_chon, DEFAULT_DATA_DIR
 from .ai_surrogate import AISurrogate
@@ -42,7 +44,7 @@ def generate_qm9_chon_ai(
 
     try:
         dataset = load_qm9_chon(max_heavy=max_heavy, data_dir=data_dir)
-    except Exception:  # pragma: no cover - dependency missing
+    except (ImportError, RuntimeError, OSError):  # pragma: no cover - dependency missing
         dataset = []
 
     surrogate = AISurrogate()
@@ -55,7 +57,7 @@ def generate_qm9_chon_ai(
             smiles = Chem.MolToSmiles(mol, canonical=True)
             scaffold = MurckoScaffold.MurckoScaffoldSmiles(mol)
             desc = _descriptor_vec(mol)
-        except Exception:
+        except (ImportError, ValueError, RuntimeError, MolSanitizeException):
             smiles = "".join(graph.atoms)
             scaffold = "NA"
             desc = [0.0] * 6

--- a/assembly_diffusion/train.py
+++ b/assembly_diffusion/train.py
@@ -119,15 +119,17 @@ def train_epoch(
             monitor.tick(step=step_in_epoch, total=total_steps)
         if monitor and (step_in_epoch % 50 == 0):
             try:
-                monitor.scalar("loss/train", float(batch_loss.detach().cpu()), step=step_in_epoch)
-            except Exception:
-                pass
+                monitor.scalar(
+                    "loss/train", float(batch_loss.detach().cpu()), step=step_in_epoch
+                )
+            except (RuntimeError, ValueError, OSError) as e:
+                logger.debug("monitor.scalar failed: %s", e)
         if monitor and (step_in_epoch % 100 == 0):
             try:
                 smi = xt_graphs[0].canonical_smiles()
                 monitor.sample_smiles([smi], step=step_in_epoch)
-            except Exception:
-                pass
+            except (RuntimeError, ValueError, OSError) as e:
+                logger.debug("monitor.sample_smiles failed: %s", e)
 
         if monitor and (time.time() - last_poke_check) > 5:
             ckpt_req, dump_req = monitor.poll()


### PR DESCRIPTION
## Summary
- restrict RDKit sanitization handling to known error types
- replace generic runtime catches with specific exceptions across pipeline and training
- harden run monitor and data utilities with targeted error checks

## Testing
- `rg -n "except\s+Exception" assembly_diffusion || true`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897e1534e68832599fc69ea94b47aed