### PR TITLE
Add ECFP4 diversity metric

### DIFF
--- a/assembly_diffusion/eval/run_smoketest.py
+++ b/assembly_diffusion/eval/run_smoketest.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import argparse
+
+try:  # pragma: no cover - RDKit optional
+    from rdkit import Chem
+except ImportError:  # pragma: no cover - handled at runtime
+    Chem = None
+
+from .metrics import Metrics
+from ..graph import MoleculeGraph
+
+
+def main() -> None:
+    """Run a tiny smoke test for the evaluation metrics."""
+
+    parser = argparse.ArgumentParser(description="Run evaluation metrics smoke test")
+    parser.add_argument("--print-metrics", action="store_true", help="Print metrics dictionary")
+    args = parser.parse_args()
+
+    if Chem is None:
+        raise ImportError("RDKit is required for the smoke test")
+
+    sample_smiles = ["CCO", "CCN", "CCC"]
+    graphs = [MoleculeGraph.from_rdkit(Chem.MolFromSmiles(s)) for s in sample_smiles]
+
+    metrics = Metrics.evaluate(graphs, reference_smiles=sample_smiles)
+    if args.print_metrics:
+        print(metrics)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- compute ECFP4 fingerprints for valid unique molecules
- calculate mean pairwise 1 - Tanimoto distance as diversity_ecfp4_mean_distance
- add simple smoke test for metrics

## Testing
- `rg --color=never -n "ECFP|MorganFingerprint|Tanimoto" assembly_diffusion || true`
- `python -m assembly_diffusion.eval.run_smoketest --print-metrics | rg "diversity_ecfp4_mean_distance" || true`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_b_6897ebdfca90832292b1f1180582f502