### PR TITLE
Fail fast when RDKit missing for metrics

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -41,7 +41,7 @@ def scaffold_diversity(smiles: Iterable[str]) -> int:
     """
 
     if Chem is None:
-        raise ImportError("RDKit is required for scaffold diversity computation")
+        raise RuntimeError("RDKit required for metric scaffold_diversity")
 
     scaffolds = set()
     for smi in smiles:

--- a/assembly_diffusion/eval/metrics.py
+++ b/assembly_diffusion/eval/metrics.py
@@ -23,7 +23,7 @@ def smiles_set(graphs: Iterable[MoleculeGraph]) -> Set[str]:
     """Return a set of canonical SMILES for valid graphs."""
 
     if Chem is None:
-        raise ImportError("RDKit is required to generate SMILES")
+        raise RuntimeError("RDKit required for metric smiles_set")
     result: Set[str] = set()
     for g in graphs:
         mol = sanitize_or_none(g)
@@ -79,7 +79,7 @@ class Metrics:
         """
 
         if Chem is None:
-            raise ImportError("RDKit is required to evaluate metrics")
+            raise RuntimeError("RDKit required for metric evaluate")
         total = len(sample_set)
         if total == 0:
             return {

--- a/tests/test_metrics_rdkit_required.py
+++ b/tests/test_metrics_rdkit_required.py
@@ -1,0 +1,14 @@
+import pytest
+from assembly_diffusion.eval import metrics
+
+
+def test_smiles_set_requires_rdkit(monkeypatch):
+    monkeypatch.setattr(metrics, "Chem", None)
+    with pytest.raises(RuntimeError, match="RDKit required for metric smiles_set"):
+        metrics.smiles_set([])
+
+
+def test_evaluate_requires_rdkit(monkeypatch):
+    monkeypatch.setattr(metrics, "Chem", None)
+    with pytest.raises(RuntimeError, match="RDKit required for metric evaluate"):
+        metrics.Metrics.evaluate([], [])


### PR DESCRIPTION
## Summary
- raise `RuntimeError` with clear messages when RDKit is missing for RDKit-dependent metrics (`smiles_set`, `Metrics.evaluate`, and `analysis.scaffold_diversity`)
- add unit tests mocking missing RDKit to ensure runtime errors are raised

## Testing
- `pytest -q tests/test_metrics_rdkit_required.py -q || true`


------
https://chatgpt.com/codex/tasks/task_b_68980d9468f08322b7ef1a462c1e13bb