### PR TITLE
Add registry scorer consistency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,5 +12,7 @@ jobs:
           push: false
           tags: local/assembly:ci
           load: true
+      - name: Check registry
+        run: docker run --rm local/assembly:ci python scripts/check_registry.py
       - name: Run tests in container
         run: docker run --rm local/assembly:ci

--- a/configs/registry.yaml
+++ b/configs/registry.yaml
@@ -14,7 +14,7 @@ experiments:
     dataset: {name: qm9_chon, split: test, limit: 0}
     seed: 42
     model: {ckpt: null, steps: 5, guidance: {enabled: true, weight: 1.0, policy: additive}}
-    ai: {scorer: surrogate, surrogate_ckpt: dummy, grammar: default, calibration: {n_mols: 0}}
+    ai: {scorer: exact, surrogate_ckpt: null, grammar: default, calibration: {n_mols: 0}}
     sampler: {n_samples: 10, batch_size: 4}
     metrics: {rdkit: true, novelty: true, uniqueness: true, diversity: internal_tanimoto}
     artifacts: {save_smiles: true, save_sdf: false, save_ai_scores: true}
@@ -24,7 +24,7 @@ experiments:
     dataset: {name: qm9_chon, split: test, limit: 0}
     seed: 42
     model: {ckpt: null, steps: 5, guidance: {enabled: true, weight: 0.5, policy: additive}}
-    ai: {scorer: surrogate, surrogate_ckpt: dummy, grammar: default, calibration: {n_mols: 0}}
+    ai: {scorer: exact, surrogate_ckpt: null, grammar: default, calibration: {n_mols: 0}}
     sampler: {n_samples: 10, batch_size: 4}
     metrics: {rdkit: true, novelty: true, uniqueness: true, diversity: internal_tanimoto}
     artifacts: {save_smiles: true, save_sdf: false, save_ai_scores: true}
@@ -34,7 +34,7 @@ experiments:
     dataset: {name: qm9_chon, split: test, limit: 0}
     seed: 42
     model: {ckpt: null, steps: 5, guidance: {enabled: true, weight: 2.0, policy: additive}}
-    ai: {scorer: surrogate, surrogate_ckpt: dummy, grammar: default, calibration: {n_mols: 0}}
+    ai: {scorer: exact, surrogate_ckpt: null, grammar: default, calibration: {n_mols: 0}}
     sampler: {n_samples: 10, batch_size: 4}
     metrics: {rdkit: true, novelty: true, uniqueness: true, diversity: internal_tanimoto}
     artifacts: {save_smiles: true, save_sdf: false, save_ai_scores: true}

--- a/scripts/check_registry.py
+++ b/scripts/check_registry.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+"""Validate experiment registry for label-to-scorer consistency."""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def main() -> None:
+    registry_path = Path(__file__).resolve().parent.parent / "configs" / "registry.yaml"
+    data = yaml.safe_load(registry_path.read_text())
+    experiments = data.get("experiments", {})
+
+    errors: list[str] = []
+    for name, cfg in experiments.items():
+        desc = cfg.get("description", "")
+        scorer = cfg.get("ai", {}).get("scorer")
+        if re.search(r"\bexact\b", desc, re.IGNORECASE) and scorer != "exact":
+            errors.append(
+                f"{name}: description indicates exact AI but ai.scorer={scorer!r}"
+            )
+
+    if errors:
+        for err in errors:
+            print(f"ERROR: {err}", file=sys.stderr)
+        sys.exit(1)
+
+    print("Registry OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- ensure experiments labelled as using exact AI actually use the exact scorer
- add a Python script to validate registry label and scorer consistency
- run the new registry check in CI

## Testing
- `python scripts/check_registry.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689812418b8c832290a90288b95dbd9e