### PR TITLE
Ensure RDKit and import checks in Docker build and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
           push: false
           tags: local/assembly:ci
           load: true
+      - name: Import check
+        run: docker run --rm local/assembly:ci micromamba run -n app python -c "import rdkit, assembly_diffusion; print('ok')"
       - name: Check registry
         run: docker run --rm local/assembly:ci micromamba run -n app python scripts/check_registry.py
       - name: Run tests in container

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,32 @@
 FROM mambaorg/micromamba:1.5.8
+
+# Build arguments
 ARG PYVER=3.11
 ARG MAMBA_DOCKERFILE_ACTIVATE=1
+
+# Create the base environment with RDKit available
 RUN micromamba create -y -n app -c conda-forge python=${PYVER} rdkit=2023.09.* \
  && micromamba clean -a -y
+
 WORKDIR /app
+
+# Install python dependencies first to leverage Docker layer caching
 COPY env.lock ./
 RUN micromamba run -n app python -m pip install --upgrade pip \
  && micromamba run -n app pip install --no-cache-dir -r env.lock --extra-index-url https://download.pytorch.org/whl/cpu
+
+# Copy the project and install in editable mode from the source tree
 COPY . /app
-RUN micromamba run -n app pip install --no-cache-dir -e .
+WORKDIR /app/assembly_diffusion
+RUN micromamba run -n app pip install --no-cache-dir -e ..
+
+# Sanity check that core modules can be imported
+RUN micromamba run -n app python - <<'PY'
+import rdkit
+import assembly_diffusion
+print('imports ok')
+PY
+
+# Default command runs the test suite
+WORKDIR /app
 CMD ["micromamba","run","-n","app","pytest","-q"]


### PR DESCRIPTION
## Summary
- install RDKit in the micromamba environment and set up project in editable mode
- run a basic rdkit/assembly_diffusion import sanity check during Docker build
- verify imports in CI before executing tests

## Testing
- `pytest -q`
- `docker build -t assembly_diffusion:dev .` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*


------
https://chatgpt.com/codex/tasks/task_b_68981e3ff40883229d5706d8d8d68411