### PR TITLE
Use logger for smoketest metrics output

### DIFF
--- a/assembly_diffusion/eval/run_smoketest.py
+++ b/assembly_diffusion/eval/run_smoketest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import logging
 
 try:  # pragma: no cover - RDKit optional
     from rdkit import Chem
@@ -17,6 +18,9 @@ try:  # pragma: no cover - optional dependencies
 except ImportError:  # pragma: no cover - handled at runtime
     AISurrogate = None
     AssemblyIndex = None
+
+
+logger = logging.getLogger(__name__)
 
 
 def main() -> None:
@@ -46,7 +50,7 @@ def main() -> None:
         metrics.update({f"exact_{k}": v for k, v in summarise_A_hat(e_scores).items()})
 
     if args.print_metrics:
-        print(metrics)
+        logger.info(metrics)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- replace direct print of metrics in smoke test with `logger.info`
- set up module-level logger

## Testing
- `rg -n "print(metrics)" assembly_diffusion/eval/run_smoketest.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689833902d688322ae20662b4d0fbfbc