### PR TITLE
Ensure deterministic algorithms in experiment script

### DIFF
--- a/scripts/experiment.py
+++ b/scripts/experiment.py
@@ -91,6 +91,8 @@ if __name__ == "__main__":
     np.random.seed(cfg["seed"])
     if torch is not None:
         torch.manual_seed(cfg["seed"])
+        if hasattr(torch, "use_deterministic_algorithms"):
+            torch.use_deterministic_algorithms(True)
 
     # run the pipeline and always write metrics.json
     metrics, flags = run_pipeline(cfg, outdir)


### PR DESCRIPTION
## Summary
- enable deterministic torch algorithms when seeding experiments

## Testing
- `rg -n "torch.use_deterministic_algorithms" scripts/experiment.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6898507962188322acdbf872d0be20c5