### PR TITLE
test: ensure metrics schema includes expected keys

### DIFF
--- a/tests/test_metrics_rdkit_required.py
+++ b/tests/test_metrics_rdkit_required.py
@@ -12,3 +12,22 @@ def test_evaluate_requires_rdkit(monkeypatch):
     monkeypatch.setattr(metrics, "Chem", None)
     with pytest.raises(RuntimeError, match="RDKit required for metric evaluate"):
         metrics.Metrics.evaluate([], [])
+
+
+def test_schema():
+    """Evaluate returns a dictionary with the expected metric keys."""
+
+    if metrics.Chem is None:
+        pytest.skip("RDKit not installed")
+    result = metrics.Metrics.evaluate([], [])
+    expected = {
+        "validity",
+        "uniqueness",
+        "diversity",
+        "novelty",
+        "qed_mean",
+        "qed_median",
+        "sa_mean",
+        "sa_median",
+    }
+    assert expected.issubset(result.keys())


### PR DESCRIPTION
## Summary
- test metrics schema for presence of expected fields

## Testing
- `pytest tests/test_metrics_rdkit_required.py::test_schema -q`

------
https://chatgpt.com/codex/tasks/task_b_689853ef3d648322a6d548277832f071