### PR TITLE
Avoid broad RDKit import exception

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -19,7 +19,7 @@ from statsmodels.genmod.cov_struct import Exchangeable
 try:  # RDKit is optional and may not be installed in every environment.
     from rdkit import Chem
     from rdkit.Chem.Scaffolds import MurckoScaffold
-except Exception:  # pragma: no cover - exercised only when RDKit is missing
+except ImportError:  # pragma: no cover - exercised only when RDKit is missing
     Chem = None
     MurckoScaffold = None
 


### PR DESCRIPTION
## Summary
- Replace generic `except Exception` with `except ImportError` when importing RDKit, ensuring failures are handled explicitly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6898611c30988322b80138a64c532d6e