### PR TITLE
Guard optional RDKit usage and pin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ To get started locally:
 
 ### RDKit
 
-RDKit is an optional dependency used for molecule manipulation and loading the QM9 dataset. It is often easier to install via conda:
+RDKit is an optional dependency used for molecule manipulation and loading the QM9 dataset. It is often easier to install a pinned version via conda:
 
 ```bash
-conda install -c conda-forge rdkit
+conda install -c conda-forge rdkit=2024.09.6
 ```
 
 Without RDKit, features such as canonical SMILES generation and QM9 dataset loading will be unavailable and will raise informative errors.

--- a/assembly_diffusion/eval/metrics.py
+++ b/assembly_diffusion/eval/metrics.py
@@ -11,7 +11,8 @@ try:  # pragma: no cover - RDKit optional
     from rdkit.Chem import AllChem
     from ..qed_sa import qed_sa_distribution
 except ImportError:  # pragma: no cover - handled at runtime
-    Chem = None
+    Chem = DataStructs = AllChem = None
+    qed_sa_distribution = None
 
 from ..graph import MoleculeGraph
 from .validity import sanitize_or_none

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ numpy
 pandas
 scipy
 statsmodels
-rdkit
+rdkit==2024.9.6
 
 networkx


### PR DESCRIPTION
## Summary
- guard `rdkit` imports in metrics with fallbacks when the library is absent
- pin `rdkit` version in requirements and installation docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6898613840b08322a06f5f3e7ff6574f