### PR TITLE
Guard RDKit import and pin dependency version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ To get started locally:
 
 ### RDKit
 
-RDKit is an optional dependency used for molecule manipulation and loading the QM9 dataset. It is often easier to install via conda:
+RDKit is an optional dependency used for molecule manipulation and loading the QM9 dataset. It is often easier to install via conda, and this project targets RDKit version `2023.09.1`:
 
 ```bash
-conda install -c conda-forge rdkit
+conda install -c conda-forge rdkit=2023.09.1
 ```
 
 Without RDKit, features such as canonical SMILES generation and QM9 dataset loading will be unavailable and will raise informative errors.

--- a/assembly_diffusion/eval/run_smoketest.py
+++ b/assembly_diffusion/eval/run_smoketest.py
@@ -31,7 +31,8 @@ def main() -> None:
     args = parser.parse_args()
 
     if Chem is None:
-        raise ImportError("RDKit is required for the smoke test")
+        logger.warning("RDKit not installed; skipping smoke test")
+        return
 
     sample_smiles = ["CCO", "CCN", "CCC"]
     graphs = [MoleculeGraph.from_rdkit(Chem.MolFromSmiles(s)) for s in sample_smiles]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ numpy
 pandas
 scipy
 statsmodels
-rdkit
+rdkit==2023.09.1
 
 networkx


### PR DESCRIPTION
## Summary
- Skip evaluation smoke test when RDKit isn't installed
- Pin `rdkit` version in requirements and README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68986141a54c8322adef92a443b162e5