### PR TITLE
Guard optional RDKit use and pin version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To get started locally:
 RDKit is an optional dependency used for molecule manipulation and loading the QM9 dataset. It is often easier to install via conda:
 
 ```bash
-conda install -c conda-forge rdkit
+conda install -c conda-forge rdkit=2023.09.6
 ```
 
 Without RDKit, features such as canonical SMILES generation and QM9 dataset loading will be unavailable and will raise informative errors.

--- a/assembly_diffusion/eval/validity.py
+++ b/assembly_diffusion/eval/validity.py
@@ -6,8 +6,10 @@ from ..graph import MoleculeGraph
 
 try:  # pragma: no cover - RDKit optional
     from rdkit.Chem.rdchem import MolSanitizeException
+    _HAS_RDKIT = True
 except ImportError:  # pragma: no cover - handled at runtime
     MolSanitizeException = RuntimeError
+    _HAS_RDKIT = False
 
 
 def sanitize_or_none(graph: MoleculeGraph):
@@ -24,9 +26,12 @@ def sanitize_or_none(graph: MoleculeGraph):
         Sanitized molecule if successful, otherwise ``None``.
     """
 
+    if not _HAS_RDKIT:
+        return None
+
     try:
         return graph.to_rdkit()
-    except (ValueError, RuntimeError, MolSanitizeException):
+    except (ValueError, RuntimeError, ImportError, MolSanitizeException):
         return None
 
 

--- a/env.lock
+++ b/env.lock
@@ -1,5 +1,6 @@
 torch==2.2.1
 statsmodels==0.14.1
+rdkit==2023.9.6
 scipy==1.11.4
 pandas==2.2.1
 pyyaml==6.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ numpy
 pandas
 scipy
 statsmodels
-rdkit
+rdkit==2023.9.6
 
 networkx


### PR DESCRIPTION
## Summary
- guard RDKit import in validity utilities and skip sanitization when unavailable
- pin rdkit dependency version in requirements, env lock, and README instructions

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'statsmodels'; OSError: /root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/torch/lib/libtorch_global_deps.so: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6898634188508322805e3326071f1fc2