### PR TITLE
Guard optional RDKit dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ To get started locally:
 ### RDKit
 
 RDKit is an optional dependency used for molecule manipulation and loading the QM9 dataset.  The project is tested against
-`rdkit` version `2024.09.6`. It is often easier to install via conda:
+`rdkit` version `2024.9.6`. It is often easier to install via conda:
 
 ```bash
-conda install -c conda-forge rdkit=2024.09.6
+conda install -c conda-forge rdkit=2024.9.6
 ```
 
 Without RDKit, features such as canonical SMILES generation and QM9 dataset loading will be unavailable and will raise informative errors.

--- a/assembly_diffusion/eval/metrics.py
+++ b/assembly_diffusion/eval/metrics.py
@@ -12,6 +12,9 @@ try:  # pragma: no cover - RDKit optional
     from ..qed_sa import qed_sa_distribution
 except ImportError:  # pragma: no cover - handled at runtime
     Chem = None
+    DataStructs = None
+    AllChem = None
+    qed_sa_distribution = None
 
 from ..graph import MoleculeGraph
 from .validity import sanitize_or_none
@@ -35,6 +38,9 @@ def smiles_set(graphs: Iterable[MoleculeGraph]) -> Set[str]:
 def _ecfp4_fingerprints(valid_smiles: List[str]) -> List[Any]:
     """Return RDKit ECFP4 fingerprints for ``valid_smiles``."""
 
+    if Chem is None or AllChem is None:
+        raise RuntimeError("RDKit required for ECFP4 fingerprints")
+
     fps: List[Any] = []
     for s in valid_smiles:
         mol = Chem.MolFromSmiles(s)
@@ -46,6 +52,9 @@ def _ecfp4_fingerprints(valid_smiles: List[str]) -> List[Any]:
 
 def _mean_pairwise_tanimoto_distance(fps: List[Any]) -> float:
     """Return the mean pairwise ``1 - Tanimoto`` distance for fingerprints."""
+
+    if DataStructs is None:
+        raise RuntimeError("RDKit required for Tanimoto similarity")
 
     if len(fps) < 2:
         return 0.0

--- a/assembly_diffusion/eval/run_smoketest.py
+++ b/assembly_diffusion/eval/run_smoketest.py
@@ -31,7 +31,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if Chem is None:
-        raise ImportError("RDKit is required for the smoke test")
+        raise ImportError("RDKit is required for the smoke test; install rdkit==2024.9.6")
 
     sample_smiles = ["CCO", "CCN", "CCC"]
     graphs = [MoleculeGraph.from_rdkit(Chem.MolFromSmiles(s)) for s in sample_smiles]

--- a/assembly_diffusion/eval/validity.py
+++ b/assembly_diffusion/eval/validity.py
@@ -26,7 +26,7 @@ def sanitize_or_none(graph: MoleculeGraph):
 
     try:
         return graph.to_rdkit()
-    except (ValueError, RuntimeError, MolSanitizeException):
+    except (ValueError, RuntimeError, ImportError, MolSanitizeException):
         return None
 
 


### PR DESCRIPTION
## Summary
- Safely handle missing RDKit by guarding optional imports in evaluation metrics and validity utilities.
- Improve smoke test feedback to specify pinned RDKit version.
- Document pinned RDKit version in README for environment setup.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_689867bd81708322ad3a785639842af0