### PR TITLE
Refine bootstrap error handling in analyzer

### DIFF
--- a/scripts/analyze_calibrators.py
+++ b/scripts/analyze_calibrators.py
@@ -41,7 +41,8 @@ def bootstrap_ci(df: pd.DataFrame, alpha: float = 0.05, B: int = 1000) -> Tuple[
         try:
             m, c, r2 = fit_logfreq_vs_A(resampled)
             m_vals.append(m)
-        except Exception:
+        except (KeyError, ValueError, np.linalg.LinAlgError) as exc:
+            logger.warning("Bootstrap iteration skipped: %s", exc)
             continue
     m_vals = np.array(m_vals)
     lo = np.quantile(m_vals, alpha/2)


### PR DESCRIPTION
## Summary
- avoid broad `except` in calibrator analysis
- log skipped bootstrap iterations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689870c25eb88322b96b1d7fb14197b3