### PR TITLE
Clarify exact vs surrogate AI configuration semantics

### DIFF
--- a/configs/registry.yaml
+++ b/configs/registry.yaml
@@ -1,8 +1,9 @@
 ## Experiment registry
 # The ``ai.scorer`` key selects how assembly indices are evaluated:
 #   - ``exact``: compute the true assembly index via the Monte-Carlo estimator.
-#   - ``surrogate``: use the fast heuristic surrogate model.  Control runs tweak
-#     the surrogate behaviour through the optional ``ai.mode`` field.
+#   - ``surrogate``: use the fast heuristic surrogate model.  ``ai.surrogate_ckpt``
+#     must point to a checkpoint and is ignored when ``ai.scorer`` is ``exact``.
+#     Control runs tweak the surrogate behaviour through the optional ``ai.mode`` field.
 experiments:
   exp01_baseline:
     description: "Unguided surrogate baseline on QM9-CHON, matched sampler settings."

--- a/configs/schema.yaml
+++ b/configs/schema.yaml
@@ -14,8 +14,8 @@ model:
     weight: float # λ in [0, 5] sensible range
     policy: "additive|multiplicative"
 ai:
-  scorer: "exact|surrogate"
-  surrogate_ckpt: str | null
+  scorer: "exact|surrogate"  # 'exact' runs the Monte-Carlo estimator; 'surrogate' uses the heuristic model
+  surrogate_ckpt: str | null # required when scorer="surrogate"; must be null for scorer="exact"
   grammar: "default"
 sampler:
   n_samples: int


### PR DESCRIPTION
## Summary
- document that `ai.scorer` accepts `exact` or `surrogate` and describe behaviour of each
- explain that `ai.surrogate_ckpt` is required for surrogate runs and ignored for exact runs

## Testing
- `python scripts/check_registry.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689870cccc40832286649fbf8cd00096