### PR TITLE
Guard RDKit imports and document pinned version

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To get started locally:
 ### RDKit
 
 RDKit is an optional dependency used for molecule manipulation and loading the QM9 dataset.  The project is tested against
-`rdkit` version `2024.9.6`. It is often easier to install via conda:
+and expects `rdkit==2024.9.6`. It is often easier to install via conda:
 
 ```bash
 conda install -c conda-forge rdkit=2024.9.6

--- a/assembly_diffusion/assembly_index.py
+++ b/assembly_diffusion/assembly_index.py
@@ -4,12 +4,14 @@ from typing import Iterable
 
 from .graph import MoleculeGraph
 
-try:  # pragma: no cover - optional dependency
+try:  # pragma: no cover - RDKit is optional
     from rdkit import Chem
     from rdkit.Chem import BRICS
+    _HAVE_RDKIT = True
 except ImportError:  # pragma: no cover - handled at runtime
-    Chem = None
-    BRICS = None
+    Chem = None  # type: ignore[assignment]
+    BRICS = None  # type: ignore[assignment]
+    _HAVE_RDKIT = False
 
 
 def fragmenter(graph: MoleculeGraph) -> Iterable[str]:
@@ -18,7 +20,7 @@ def fragmenter(graph: MoleculeGraph) -> Iterable[str]:
     If RDKit is unavailable a crude fallback concatenates atomic symbols into a
     single fragment.
     """
-    if Chem is None or BRICS is None:
+    if not _HAVE_RDKIT:
         return ["".join(graph.atoms)]
     mol = graph.to_rdkit()
     return list(BRICS.BRICSDecompose(mol))


### PR DESCRIPTION
## Summary
- add `_HAVE_RDKIT` flag to safely handle missing RDKit in `assembly_index.fragmenter`
- document that the project expects `rdkit==2024.9.6`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6898756b780c8322a671c9a58611c348