### PR TITLE
Define evaluation metrics

### DIFF
--- a/scripts/experiment.py
+++ b/scripts/experiment.py
@@ -5,7 +5,11 @@ baseline: the default configuration and its reference metrics act as
 data_sources: experiment settings and model paths are loaded from
     ``configs/registry.yaml`` along with generated artifacts.
 metrics: pipeline evaluation statistics are written via
-    ``metrics_writer`` such as validity and AI score summaries.
+    ``metrics_writer`` such as validity and AI score summaries. Classification
+    quality follows the F1 score ``F1 = 2 * precision * recall / (precision +
+    recall)`` while regression error uses the mean squared error
+    ``MSE = (1/N) * Σ_i (y_i - ŷ_i)^2``.  When multiple random seeds are run the
+    results should be reported as ``mean ± std`` across seeds.
 objective: execute a single experiment and persist a manifest with
     environment details for downstream analysis.
 validation: smoke tests like ``tests/test_pipeline_smoke.py`` ensure the

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -8,7 +8,11 @@ method: invoke functions from :mod:`analysis` to compute statistical
     comparisons and diversity metrics.
 metrics: Kolmogorov–Smirnov p-values, scaffold counts, regression
     parameters, bootstrap medians, sensitivity medians, error quantiles and
-    calibration curves.
+    calibration curves. Classification quality uses the F1 score
+    ``F1 = 2 * precision * recall / (precision + recall)`` while regression error
+    is measured by the mean squared error ``MSE = (1/N) * Σ_i (y_i - ŷ_i)^2``.
+    When results are aggregated over multiple random seeds they should be
+    reported as ``mean ± std``.
 objective: verify the analysis utilities produce correct and stable
     statistics across a range of scenarios.
 params: tests exercise options such as bootstrap iterations, quantiles and


### PR DESCRIPTION
## Summary
- Clarify experiment runner metrics by defining F1 and MSE formulas and reporting as mean ± std over seeds
- Document F1 and MSE definitions alongside other analysis metrics and clarify seed-averaged reporting in tests

## Testing
- `pytest tests/test_analysis.py`

------
https://chatgpt.com/codex/tasks/task_b_689880c589d88322ac455bfb491188f6