### PR TITLE
Add experiment specs for calibrator analysis and surrogate training

### DIFF
--- a/scripts/analyze_calibrators.py
+++ b/scripts/analyze_calibrators.py
@@ -1,12 +1,31 @@
+"""Experiment specification for analyzing calibrator outputs.
+
+baseline: frequency tables produced by ``scripts/run_calibrators.py`` serve as
+    the reference distributions.
+method: load a calibrator CSV, fit a trimmed log–linear model of frequency
+    versus ``A`` and bootstrap slope estimates; measure Spearman correlation of
+    degeneracy against frequency.
+metrics: slope ``m``, intercept ``c``, coefficient of determination ``R²``,
+    bootstrap confidence interval for ``m`` and Spearman ``ρ``/``p`` for
+    degeneracy.
+objective: quantify how calibration frequency scales with assembly size and how
+    degeneracy relates to frequency.
+repro: ``python scripts/analyze_calibrators.py path/to/calibs.csv --alpha 0.05
+    --boot 1000`` reproduces the reported statistics.
+validation: ``pytest tests/test_calibrators.py`` and
+    ``pytest tests/test_analysis.py`` exercise the samplers and statistical
+    helpers used here.
+"""
+
 from __future__ import annotations
+
 import argparse
-import argparse
+import logging
+from typing import Tuple
+
 import numpy as np
 import pandas as pd
-from typing import Tuple
-from math import log
 from scipy.stats import spearmanr
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/scripts/train_surrogate.py
+++ b/scripts/train_surrogate.py
@@ -1,3 +1,21 @@
+"""Experiment specification for training the assembly-index surrogate model.
+
+baseline: a mean-value predictor establishes the performance to surpass.
+data_sources: molecular descriptors and assembly indices loaded from
+    ``qm9_chon_ai.csv`` provide features and labels.
+method: read the dataset, train a PyTorch regression model with k-fold cross
+    validation and save resulting metrics and artifacts.
+objective: learn a fast surrogate capable of approximating the exact assembly
+    index computation.
+params: model architecture, learning rate, random seed and number of folds
+    control the training behaviour.
+repro: running ``python scripts/train_surrogate.py`` writes ``cv_metrics.json``,
+    ``model.pt`` and ``calibration_plot.png`` into a timestamped ``results``
+    subdirectory.
+validation: smoke tests such as ``tests/test_guidance.py`` ensure surrogate
+    predictions integrate correctly with the diffusion pipeline.
+"""
+
 import json, os, time, numpy as np, torch, logging
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- Document baseline, method, metrics, and reproducibility details for calibrator analysis
- Document baseline, data sources, parameters, and validation approach for surrogate model training

## Testing
- `pytest tests/test_calibrators.py tests/test_analysis.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689880b0c65883228cd5d57707851501