### PR TITLE
Guard RDKit use in QM9 utilities

### DIFF
--- a/assembly_diffusion/qm9_ai.py
+++ b/assembly_diffusion/qm9_ai.py
@@ -17,6 +17,14 @@ except ImportError:  # pragma: no cover - handled at runtime
     MurckoScaffold = None
     MolSanitizeException = RuntimeError
 
+
+def _require_rdkit() -> None:
+    """Raise an informative error if RDKit is unavailable."""
+    if Chem is None or Descriptors is None or rdMolDescriptors is None or MurckoScaffold is None:
+        raise ImportError(
+            "RDKit is required for QM9 annotations. Install it via 'conda install -c conda-forge rdkit'."
+        )
+
 from .data import load_qm9_chon, DEFAULT_DATA_DIR
 from .ai_surrogate import AISurrogate
 from .ai_mc import AssemblyMC
@@ -24,6 +32,7 @@ from .ai_mc import AssemblyMC
 
 def _descriptor_vec(mol: "Chem.Mol") -> List[float]:
     """Return a vector of six basic RDKit descriptors."""
+    _require_rdkit()
     return [
         Descriptors.MolWt(mol),
         Descriptors.MolLogP(mol),
@@ -53,6 +62,7 @@ def generate_qm9_chon_ai(
     rows = []
     for graph in dataset:
         try:
+            _require_rdkit()
             mol = graph.to_rdkit()
             smiles = Chem.MolToSmiles(mol, canonical=True)
             scaffold = MurckoScaffold.MurckoScaffoldSmiles(mol)


### PR DESCRIPTION
## Summary
- Add optional RDKit import and explicit `_require_rdkit` guard in QM9 data loader
- Require RDKit for QM9 annotation helper and provide clean fallback path when absent

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6898808812848322815be34ee855a4ea