### PR TITLE
feat: seed and log environment for reproducibility

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -25,12 +25,46 @@ from __future__ import annotations
 
 from typing import Iterable, Dict, Sequence
 
+import logging
+import platform
+import random
+import subprocess
+
 import numpy as np
 import pandas as pd
+import scipy
+import statsmodels
 from scipy.stats import ks_2samp
 from statsmodels.genmod.generalized_estimating_equations import GEE
 from statsmodels.genmod.families import Binomial
 from statsmodels.genmod.cov_struct import Exchangeable
+
+logger = logging.getLogger(__name__)
+
+
+def _log_environment(seed: int = 0) -> None:
+    """Seed RNGs and log version information for reproducibility."""
+
+    random.seed(seed)
+    np.random.seed(seed)
+    try:
+        commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    except Exception:  # pragma: no cover - git may be unavailable
+        commit = "unknown"
+    logger.info(
+        "Reproducibility: seed=%s python=%s numpy=%s pandas=%s scipy=%s statsmodels=%s commit=%s",
+        seed,
+        platform.python_version(),
+        np.__version__,
+        pd.__version__,
+        scipy.__version__,
+        statsmodels.__version__,
+        commit,
+    )
+
+
+_log_environment()
+
 
 try:  # RDKit is optional and may not be installed in every environment.
     from rdkit import Chem

--- a/assembly_diffusion/eval/run_smoketest.py
+++ b/assembly_diffusion/eval/run_smoketest.py
@@ -25,6 +25,11 @@ from __future__ import annotations
 
 import argparse
 import logging
+import platform
+import random
+import subprocess
+
+import numpy as np
 
 try:  # pragma: no cover - RDKit optional
     from rdkit import Chem
@@ -52,6 +57,20 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Run evaluation metrics smoke test")
     parser.add_argument("--print-metrics", action="store_true", help="Print metrics dictionary")
     args = parser.parse_args()
+
+    random.seed(0)
+    np.random.seed(0)
+    try:
+        commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    except Exception:  # pragma: no cover - git may be unavailable
+        commit = "unknown"
+    logger.info(
+        "Reproducibility: seed=%s python=%s numpy=%s commit=%s",
+        0,
+        platform.python_version(),
+        np.__version__,
+        commit,
+    )
 
     if Chem is None:
         raise ImportError("RDKit is required for the smoke test; install rdkit==2024.9.6")


### PR DESCRIPTION
## Summary
- ensure analysis utilities seed RNGs and report Python/package versions with commit SHA
- seed smoke test and log environment information for reproducible runs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68991ec729948322bf6df24fcbdbd8dc