### PR TITLE
Add validity baseline comparison utilities

### DIFF
--- a/assembly_diffusion/eval/validity.py
+++ b/assembly_diffusion/eval/validity.py
@@ -28,6 +28,7 @@ import random
 import subprocess
 from pathlib import Path
 from importlib import metadata
+from typing import Iterable, Mapping, Sequence, Dict
 
 from ..graph import MoleculeGraph
 from ..logging_config import get_logger
@@ -117,3 +118,41 @@ def is_valid(graph: MoleculeGraph) -> bool:
     """Return ``True`` if ``graph`` can be sanitized by RDKit."""
 
     return sanitize_or_none(graph) is not None
+
+
+def validity_rate(graphs: Iterable[MoleculeGraph]) -> float:
+    """Return the fraction of RDKit-valid graphs in ``graphs``.
+
+    Parameters
+    ----------
+    graphs:
+        Any iterable of :class:`~assembly_diffusion.graph.MoleculeGraph`.
+
+    Returns
+    -------
+    float
+        The proportion of graphs that can be sanitised by RDKit. ``0.0`` is
+        returned for an empty iterable.
+    """
+
+    total = 0
+    valid = 0
+    for g in graphs:
+        total += 1
+        if is_valid(g):
+            valid += 1
+    return valid / total if total else 0.0
+
+
+def compare_validity_runs(
+    runs: Mapping[str, Sequence[MoleculeGraph]]
+) -> Dict[str, float]:
+    """Return validity rates for each named run.
+
+    ``runs`` maps run names to sequences of graphs, with the entry labelled
+    ``"baseline"`` typically representing the control condition. The function
+    computes :func:`validity_rate` for every run to enable baseline
+    comparisons or ablation studies.
+    """
+
+    return {name: validity_rate(graphs) for name, graphs in runs.items()}

--- a/tests/test_validity_baselines.py
+++ b/tests/test_validity_baselines.py
@@ -1,0 +1,31 @@
+import pytest
+import torch
+from rdkit import Chem
+
+from assembly_diffusion.graph import MoleculeGraph
+from assembly_diffusion.eval.validity import validity_rate, compare_validity_runs
+
+
+def _valid_graph():
+    mol = Chem.MolFromSmiles("CC")
+    return MoleculeGraph.from_rdkit(mol)
+
+
+def _invalid_graph():
+    bonds = torch.tensor([[0, 4], [4, 0]], dtype=torch.int64)
+    return MoleculeGraph(["C", "C"], bonds)
+
+
+def test_validity_rate():
+    graphs = [_valid_graph(), _invalid_graph()]
+    assert validity_rate(graphs) == pytest.approx(0.5)
+
+
+def test_compare_validity_runs():
+    runs = {
+        "baseline": [_invalid_graph()],
+        "model": [_valid_graph(), _invalid_graph()],
+    }
+    results = compare_validity_runs(runs)
+    assert results["baseline"] == 0.0
+    assert results["model"] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- add `validity_rate` and `compare_validity_runs` helpers for RDKit validity baselines
- document baseline use cases and enable comparison of multiple runs
- test baseline utilities using valid and invalid `MoleculeGraph` examples

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68991f1b89dc8322b11103fce77a107a