### PR TITLE
Document validation protocol

### DIFF
--- a/assembly_diffusion/__main__.py
+++ b/assembly_diffusion/__main__.py
@@ -13,8 +13,10 @@ objective: demonstrate launching and evaluating a configured experiment.
 params: experiment parameters come from ``configs/registry.yaml`` and any CLI
     overrides.
 repro: deterministic seeds and committed configs ensure reproducibility.
-validation: ``scripts/check_registry.py`` and unit tests verify experiment
-    setup.
+validation: experiments rely on an 80/10/10 train/validation/test split with
+    the best checkpoint chosen by validation F1.  Training may stop early when
+    that score fails to improve for a set patience.  ``scripts/check_registry.py``
+    and unit tests verify experiment setup.
 """
 
 from .cli import main

--- a/assembly_diffusion/eval/metrics_writer.py
+++ b/assembly_diffusion/eval/metrics_writer.py
@@ -10,8 +10,10 @@ params: ``outdir`` destination directory and ``**metrics`` arbitrary name/value
     pairs where numbers are cast to ``float`` or ``int``.
 repro: serialisation is deterministic; identical inputs yield identical
     ``metrics.json`` files.
-validation: tests or downstream consumers can load ``metrics.json`` and check
-    for expected keys and numeric types.
+validation: results typically include train, validation and test metrics along
+    with optional ``best_epoch`` from early stopping.  Tests or downstream
+    consumers can load ``metrics.json`` and check for expected keys and numeric
+    types.
 """
 
 from __future__ import annotations

--- a/scripts/experiment.py
+++ b/scripts/experiment.py
@@ -12,8 +12,11 @@ metrics: pipeline evaluation statistics are written via
     results should be reported as ``mean ± std`` across seeds.
 objective: execute a single experiment and persist a manifest with
     environment details for downstream analysis.
-validation: smoke tests like ``tests/test_pipeline_smoke.py`` ensure the
-    script runs end to end and produces metrics.
+validation: experiments report separate metrics for train, validation and test
+    splits.  The best model checkpoint is selected by the highest validation
+    F1 score and training may stop early when that score plateaus for a
+    configured patience.  Smoke tests like ``tests/test_pipeline_smoke.py``
+    ensure the script runs end to end and produces metrics.
 """
 
 import hashlib, json, os, subprocess, sys, time, yaml, logging

--- a/scripts/train_surrogate.py
+++ b/scripts/train_surrogate.py
@@ -5,6 +5,9 @@ data_sources: molecular descriptors and assembly indices loaded from
     ``qm9_chon_ai.csv`` provide features and labels.
 method: read the dataset, train a PyTorch regression model with k-fold cross
     validation and save resulting metrics and artifacts.
+validation: each fold uses an internal train/validation split with the model
+    chosen by lowest validation mean absolute error (MAE).  Training halts
+    early when the validation MAE fails to improve for a configured patience.
 objective: learn a fast surrogate capable of approximating the exact assembly
     index computation.
 params: model architecture, learning rate, random seed and number of folds

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -20,7 +20,9 @@ params: tests exercise options such as bootstrap iterations, quantiles and
 repro: deterministic NumPy operations and fixed random seeds yield
     reproducible outputs.
 validation: running ``pytest tests/test_analysis.py`` executes the
-    assertions below.
+    assertions below, including checks for ``train_val_test_split`` and
+    ``early_stopping`` which formalise dataset partitioning and early
+    termination when validation metrics stagnate.
 """
 
 import numpy as np


### PR DESCRIPTION
## Summary
- outline fold-wise train/validation splits and early stopping for surrogate training
- clarify experiment runner selection criteria and early stopping behaviour
- document validation helpers and result serialization conventions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68991f5dfdfc83228bd90c4869a49e69