### PR TITLE
Refine logging exception handling

### DIFF
--- a/assembly_diffusion/monitor.py
+++ b/assembly_diffusion/monitor.py
@@ -274,8 +274,12 @@ class RunMonitor:
             pass
         try:
             logger.error(err)
-        except Exception:  # pragma: no cover - logging failure is non-critical
-            pass
+        except (OSError, RuntimeError):  # pragma: no cover - logging failure is non-critical
+            try:
+                sys.stderr.write(err + "\n")
+            except OSError:
+                # If writing to stderr fails, there's nothing further we can do.
+                pass
         self._error_logged = True
 
     def _roll_existing_jsonl(self, today: str) -> None:


### PR DESCRIPTION
## Summary
- Replace broad logging exception handler in run monitor with explicit `OSError`/`RuntimeError` catch and stderr fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689925bc75e48322bc262263b3e40f90