### PR TITLE
feat: add cross-validation to calibrator analysis

### DIFF
--- a/scripts/analyze_calibrators.py
+++ b/scripts/analyze_calibrators.py
@@ -25,18 +25,22 @@ repro: ``python scripts/analyze_calibrators.py path/to/calibs.csv --alpha 0.05
     --boot 1000`` reproduces the reported statistics.
 validation: ``pytest tests/test_calibrators.py`` and
     ``pytest tests/test_analysis.py`` exercise the samplers and statistical
-    helpers used here.
+    helpers used here.  Optional cross-validation (``--cv``) selects the model
+    with the highest validation ``R²`` and early stopping (``--patience``)
+    halts evaluation when this metric fails to improve for consecutive folds.
 """
 
 from __future__ import annotations
 
 import argparse
 import logging
-from typing import Tuple
+from typing import Tuple, Dict
 
 import numpy as np
 import pandas as pd
 from scipy.stats import spearmanr
+
+from analysis import early_stopping
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +48,8 @@ parser = argparse.ArgumentParser()
 parser.add_argument("csv", type=str)
 parser.add_argument("--alpha", type=float, default=0.05)
 parser.add_argument("--boot", type=int, default=1000)
+parser.add_argument("--cv", type=int, default=1, help="number of cross-validation folds")
+parser.add_argument("--patience", type=int, default=0, help="early stopping patience in folds")
 
 
 def fit_logfreq_vs_A(df: pd.DataFrame, trim_quant: float = 0.05) -> Tuple[float, float, float]:
@@ -80,6 +86,63 @@ def bootstrap_ci(df: pd.DataFrame, alpha: float = 0.05, B: int = 1000) -> Tuple[
     return float(lo), float(hi)
 
 
+def eval_logfreq_vs_A(
+    df: pd.DataFrame, m: float, c: float, trim_quant: float = 0.05
+) -> float:
+    """Evaluate ``R²`` of a pre-fit model ``y = mA + c`` on ``df``."""
+
+    df = df.copy()
+    df["A"] = df["As_upper"].astype(int)
+    grouped = df.groupby("A")["frequency"].sum().reset_index()
+    lo, hi = grouped["A"].quantile([trim_quant, 1 - trim_quant])
+    mask = (grouped["A"] >= lo) & (grouped["A"] <= hi)
+    trimmed = grouped[mask]
+    if trimmed.empty:
+        return np.nan
+    X = trimmed["A"].to_numpy()
+    y = np.log(np.maximum(trimmed["frequency"].to_numpy(), 1e-12))
+    yhat = m * X + c
+    ss_res = np.sum((y - yhat) ** 2)
+    ss_tot = np.sum((y - np.mean(y)) ** 2)
+    return float(1.0 - ss_res / ss_tot) if ss_tot > 0 else 0.0
+
+
+def kfold_cv(df: pd.DataFrame, k: int, patience: int = 0) -> Dict[str, float]:
+    """Return metrics from k-fold cross-validation with early stopping."""
+
+    rng = np.random.default_rng(0)
+    indices = rng.permutation(len(df))
+    fold_sizes = np.full(k, len(df) // k, dtype=int)
+    fold_sizes[: len(df) % k] += 1
+    start = 0
+    val_history = []
+    metrics = []
+    for fold_idx, fold_size in enumerate(fold_sizes):
+        stop = start + fold_size
+        val_idx = indices[start:stop]
+        train_idx = np.concatenate([indices[:start], indices[stop:]])
+        train_df = df.iloc[train_idx]
+        val_df = df.iloc[val_idx]
+        try:
+            m, c, r2_train = fit_logfreq_vs_A(train_df)
+            r2_val = eval_logfreq_vs_A(val_df, m, c)
+        except (KeyError, ValueError, np.linalg.LinAlgError) as exc:
+            logger.warning("Cross-validation fold %d skipped: %s", fold_idx, exc)
+            start = stop
+            continue
+        metrics.append({"m": m, "c": c, "R2_train": r2_train, "R2_val": r2_val})
+        val_history.append(r2_val)
+        if patience and early_stopping(val_history, patience=patience):
+            logger.info("Early stopping after %d folds", fold_idx + 1)
+            break
+        start = stop
+    if not metrics:
+        raise RuntimeError("No valid folds for cross-validation")
+    best = max(metrics, key=lambda d: d["R2_val"])
+    best["folds_evaluated"] = len(metrics)
+    return best
+
+
 def degeneracy_spearman(df: pd.DataFrame) -> Tuple[float, float]:
     sub = df.dropna(subset=["d_min"]).copy()
     if sub.empty:
@@ -98,17 +161,33 @@ def degeneracy_spearman(df: pd.DataFrame) -> Tuple[float, float]:
 if __name__ == "__main__":
     args = parser.parse_args()
     df = pd.read_csv(args.csv)
-    m, c, r2 = fit_logfreq_vs_A(df)
-    m_lo, m_hi = bootstrap_ci(df, alpha=args.alpha, B=args.boot)
-    rho, p = degeneracy_spearman(df)
-    logger.info(
-        "%s",
-        {
-            "m": m,
-            "m_CI": [m_lo, m_hi],
-            "R2": r2,
-            "rho_deg": rho,
-            "p_deg": p,
-            "N_rows": int(df.shape[0]),
-        },
-    )
+    if args.cv > 1:
+        best = kfold_cv(df, args.cv, patience=args.patience)
+        rho, p = degeneracy_spearman(df)
+        logger.info(
+            "%s",
+            {
+                "m": best["m"],
+                "R2_train": best["R2_train"],
+                "R2_val": best["R2_val"],
+                "rho_deg": rho,
+                "p_deg": p,
+                "folds": best["folds_evaluated"],
+                "N_rows": int(df.shape[0]),
+            },
+        )
+    else:
+        m, c, r2 = fit_logfreq_vs_A(df)
+        m_lo, m_hi = bootstrap_ci(df, alpha=args.alpha, B=args.boot)
+        rho, p = degeneracy_spearman(df)
+        logger.info(
+            "%s",
+            {
+                "m": m,
+                "m_CI": [m_lo, m_hi],
+                "R2": r2,
+                "rho_deg": rho,
+                "p_deg": p,
+                "N_rows": int(df.shape[0]),
+            },
+        )


### PR DESCRIPTION
## Summary
- support optional k-fold cross-validation in `analyze_calibrators.py`
- add early-stopping based on validation R²
- document model selection and stopping criteria

## Testing
- `pytest tests/test_calibrators.py tests/test_analysis.py`


------
https://chatgpt.com/codex/tasks/task_b_689925d8dc3c8322930bdc60996413b9