### PR TITLE
Add reproducibility utilities and seed setup

### DIFF
--- a/assembly_diffusion/__main__.py
+++ b/assembly_diffusion/__main__.py
@@ -20,6 +20,8 @@ validation: experiments rely on an 80/10/10 train/validation/test split with
 """
 
 from .cli import main
+from .repro import setup_reproducibility
 
 if __name__ == "__main__":
+    setup_reproducibility(0)
     main()

--- a/assembly_diffusion/eval/metrics_writer.py
+++ b/assembly_diffusion/eval/metrics_writer.py
@@ -23,6 +23,8 @@ import os
 from pathlib import Path
 from typing import Any
 
+from ..repro import setup_reproducibility
+
 SCHEMA_VERSION = "1.1"
 
 
@@ -46,6 +48,9 @@ def write_metrics(outdir: str, **metrics: Any) -> None:
         for JSON serialisation; other types (e.g. lists for CIs) are stored as
         provided.
     """
+
+    seed = int(metrics.get("seed", 0))
+    setup_reproducibility(seed)
 
     payload: dict[str, Any] = {"schema_version": SCHEMA_VERSION}
     for key, value in metrics.items():

--- a/assembly_diffusion/repro.py
+++ b/assembly_diffusion/repro.py
@@ -1,0 +1,65 @@
+"""Utilities for reproducible experiments."""
+
+from __future__ import annotations
+
+import logging
+import platform
+import random
+import subprocess
+
+import numpy as np
+
+try:  # Optional dependencies; versions logged if installed
+    import pandas as pd
+except Exception:  # pragma: no cover - pandas may be absent
+    pd = None  # type: ignore
+
+try:
+    import scipy
+except Exception:  # pragma: no cover - scipy may be absent
+    scipy = None  # type: ignore
+
+try:
+    import statsmodels
+except Exception:  # pragma: no cover - statsmodels may be absent
+    statsmodels = None  # type: ignore
+
+try:
+    import torch
+except Exception:  # pragma: no cover - torch may be absent
+    torch = None  # type: ignore
+
+
+def setup_reproducibility(seed: int = 0) -> None:
+    """Seed RNGs and log environment information.
+
+    Parameters
+    ----------
+    seed:
+        Random seed used to initialise ``random``, ``numpy`` and, if available,
+        ``torch``.  Environment details and selected package versions are logged
+        alongside the current Git commit SHA.
+    """
+
+    random.seed(seed)
+    np.random.seed(seed)
+    if torch is not None:
+        torch.manual_seed(seed)
+
+    try:
+        commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    except Exception:  # pragma: no cover - git may be unavailable
+        commit = "unknown"
+
+    logger = logging.getLogger(__name__)
+    logger.info(
+        "Reproducibility: seed=%s python=%s numpy=%s pandas=%s scipy=%s statsmodels=%s torch=%s commit=%s",
+        seed,
+        platform.python_version(),
+        np.__version__,
+        pd.__version__ if pd is not None else "N/A",
+        scipy.__version__ if scipy is not None else "N/A",
+        statsmodels.__version__ if statsmodels is not None else "N/A",
+        torch.__version__ if torch is not None else "N/A",
+        commit,
+    )

--- a/scripts/train_surrogate.py
+++ b/scripts/train_surrogate.py
@@ -22,6 +22,11 @@ validation: smoke tests such as ``tests/test_guidance.py`` ensure surrogate
 import json, os, time, numpy as np, torch, logging
 from pathlib import Path
 
+from assembly_diffusion.repro import setup_reproducibility
+
+SEED = int(os.environ.get("SEED", "0"))
+setup_reproducibility(SEED)
+
 logger = logging.getLogger(__name__)
 
 # TODO(#1, @model-team, 2024-10-01): load features + labels, define model, train, k-fold, save metrics

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -29,6 +29,10 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from assembly_diffusion.repro import setup_reproducibility
+
+setup_reproducibility(0)
+
 from analysis import (
     ks_test,
     scaffold_diversity,


### PR DESCRIPTION
## Summary
- Add `setup_reproducibility` utility to seed RNGs and log environment details including package versions and commit SHA.
- Seed and log reproducibility info in training script, CLI entrypoint, metrics writer, and analysis tests.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6899260c5a588322a0dc1c489c72644d