### PR TITLE
feat: guard pipeline RDKit requirement

### DIFF
--- a/assembly_diffusion/pipeline.py
+++ b/assembly_diffusion/pipeline.py
@@ -290,7 +290,8 @@ def run_pipeline(
     (e.g. when RDKit is unavailable).
     """
     # 1) Sanity checks and RDKit requirement
-    # RDKit is optional for smoke tests. Metrics are gated below.
+    # RDKit is optional; enforce only if RDKit metrics are enabled.
+    _require_rdkit(cfg)
 
     # 2) Sample molecules using existing sampler
     n_samples = int(cfg["sampler"]["n_samples"])


### PR DESCRIPTION
## Summary
- ensure pipeline raises early when RDKit metrics requested but dependency missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6899369473b48322934d03068087828f