### PR TITLE
Add conda environment and Dockerfile with pinned RDKit

### DIFF
--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -1,0 +1,12 @@
+FROM condaforge/miniforge3
+
+WORKDIR /app
+
+COPY env.lock env.lock
+COPY env/conda.yml conda.yml
+
+RUN conda env create -f conda.yml && conda clean -afy
+
+SHELL ["conda", "run", "-n", "assembly_diffusion", "/bin/bash", "-c"]
+
+CMD ["python", "-c", "import rdkit, torch; print(rdkit.__version__)"]

--- a/env/conda.yml
+++ b/env/conda.yml
@@ -1,0 +1,9 @@
+name: assembly_diffusion
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - rdkit=2024.09.6
+  - pip
+  - pip:
+      - -r env.lock


### PR DESCRIPTION
## Summary
- Provide a conda environment specification pinned to Python 3.10 and RDKit 2024.09.6
- Add a Miniforge-based Dockerfile that installs RDKit via conda and remaining Python dependencies via pip

## Testing
- `conda env create -f env/conda.yml` *(fails: ProxyError: Conda cannot proceed due to an error in your proxy configuration)*
- `docker build -f env/Dockerfile .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_b_68999325339c8322843a34713fbe3d0f