### PR TITLE
feat: add run configuration

### DIFF
--- a/assembly_diffusion/config.py
+++ b/assembly_diffusion/config.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, get_type_hints
+from typing import Any, Dict, List, get_type_hints
 
 import yaml
 
@@ -29,6 +29,25 @@ class SamplingConfig:
     guidance_mode: str = "A_lower"
     max_steps: int = 64
     delta_valid_tol: float = 0.05
+
+
+@dataclass
+class AIConfig:
+    """Configuration options for assembly index estimation."""
+
+    method: str = "surrogate"
+    trials: int = 1
+    timeout_s: float = 0.0
+
+
+@dataclass
+class RunConfig:
+    """Top level run configuration."""
+
+    seeds: List[int]
+    N_samp: int
+    guidance: float
+    ai: AIConfig
 
 
 def load_config(path: str | Path, variant: str) -> TrainConfig:
@@ -67,3 +86,36 @@ def load_config(path: str | Path, variant: str) -> TrainConfig:
                 raise TypeError(f"Invalid value for '{key}': {merged[key]}") from exc
 
     return TrainConfig(**merged)
+
+
+def load_run_config(path: str | Path) -> RunConfig:
+    """Load a YAML run configuration file.
+
+    Parameters
+    ----------
+    path:
+        Path to a YAML file describing a run.  Expected keys are
+        ``seeds`` (list of ints), ``N_samp`` (int), ``guidance`` (float) and
+        an ``ai`` section with ``method``, ``trials`` and ``timeout_s``.
+    """
+
+    with open(Path(path), "r", encoding="utf8") as f:
+        raw: Dict[str, Any] = yaml.safe_load(f) or {}
+
+    seeds_raw = raw.get("seeds", [])
+    seeds = [int(s) for s in (seeds_raw if isinstance(seeds_raw, list) else [seeds_raw])]
+
+    ai_raw = raw.get("ai", {})
+    ai_cfg = AIConfig(
+        method=str(ai_raw.get("method", "surrogate")),
+        trials=int(ai_raw.get("trials", 1)),
+        timeout_s=float(ai_raw.get("timeout_s", 0.0)),
+    )
+
+    cfg = RunConfig(
+        seeds=seeds,
+        N_samp=int(raw.get("N_samp", 0)),
+        guidance=float(raw.get("guidance", 0.0)),
+        ai=ai_cfg,
+    )
+    return cfg

--- a/configs/run.yml
+++ b/configs/run.yml
@@ -1,0 +1,7 @@
+seeds: [0]
+N_samp: 8
+guidance: 0.0
+ai:
+  method: surrogate
+  trials: 1
+  timeout_s: 5

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -1,0 +1,28 @@
+from assembly_diffusion.config import load_run_config
+from assembly_diffusion.cli import build_ai
+
+
+def _write_cfg(path, method):
+    path.write_text(
+        """seeds: [0]
+N_samp: 1
+guidance: 0.0
+ai:
+  method: {method}
+  trials: 1
+  timeout_s: 1
+""".format(method=method)
+    )
+
+
+def test_ai_method_toggle(tmp_path):
+    cfg_path = tmp_path / "run.yml"
+    _write_cfg(cfg_path, "surrogate")
+    cfg = load_run_config(cfg_path)
+    ai = build_ai(cfg.ai.method)
+    assert ai.__class__.__name__ == "AISurrogate"
+
+    _write_cfg(cfg_path, "assemblymc")
+    cfg = load_run_config(cfg_path)
+    ai = build_ai(cfg.ai.method)
+    assert ai.__class__.__name__ == "AssemblyMC"


### PR DESCRIPTION
## Summary
- add dataclasses and loader for run config
- wire CLI to parse --config/--dry-run and select AI method
- add default run config and tests for method switching

## Testing
- `python -m assembly_diffusion --config configs/run.yml --dry-run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6899933ad788832285857bf8c4aa3caf