### PR TITLE
Add protocol CSV schema writer

### DIFF
--- a/assembly_diffusion/io/__init__.py
+++ b/assembly_diffusion/io/__init__.py
@@ -1,0 +1,17 @@
+"""I/O helpers for Assembly Diffusion."""
+
+from .schema import (
+    ProtocolRow,
+    PROTOCOL_COLUMNS,
+    PROTOCOL_DTYPES,
+    write_protocol_csv,
+    read_protocol_csv,
+)
+
+__all__ = [
+    "ProtocolRow",
+    "PROTOCOL_COLUMNS",
+    "PROTOCOL_DTYPES",
+    "write_protocol_csv",
+    "read_protocol_csv",
+]

--- a/assembly_diffusion/io/schema.py
+++ b/assembly_diffusion/io/schema.py
@@ -1,0 +1,95 @@
+"""CSV schema definitions and helpers.
+
+The project logs protocol summaries as comma-separated values with a fixed
+schema.  :func:`write_protocol_csv` ensures that rows are written in a stable
+order and normalises numeric types for downstream processing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import csv
+from typing import Iterable
+
+import pandas as pd
+
+# Column names and dtypes expected by downstream tooling.  The order here is
+# important and is used when writing header rows.
+PROTOCOL_COLUMNS = [
+    "id",
+    "universe",
+    "grammar",
+    "As_lower",
+    "As_upper",
+    "validity",
+    "frequency",
+    "d_min",
+]
+
+PROTOCOL_DTYPES: dict[str, str] = {
+    "id": "string",
+    "universe": "string",
+    "grammar": "string",
+    "As_lower": "int64",
+    "As_upper": "int64",
+    "validity": "float64",
+    "frequency": "float64",
+    "d_min": "float64",
+}
+
+
+@dataclass
+class ProtocolRow:
+    """Representation of a single protocol summary row."""
+
+    id: str
+    universe: str
+    grammar: str
+    As_lower: int
+    As_upper: int
+    validity: float
+    frequency: float
+    d_min: float
+
+
+def write_protocol_csv(path: str, rows: Iterable[ProtocolRow]) -> None:
+    """Write ``rows`` to ``path`` using the protocol CSV schema.
+
+    Parameters
+    ----------
+    path:
+        Destination CSV file path.
+    rows:
+        Iterable of :class:`ProtocolRow` instances that will be written in the
+        given order.  Values are normalised to the dtypes specified in
+        :data:`PROTOCOL_DTYPES`.
+    """
+
+    with open(path, "w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(PROTOCOL_COLUMNS)
+        for r in rows:
+            writer.writerow(
+                [
+                    str(r.id),
+                    str(r.universe),
+                    str(r.grammar),
+                    int(r.As_lower),
+                    int(r.As_upper),
+                    float(r.validity),
+                    float(r.frequency),
+                    float(r.d_min),
+                ]
+            )
+
+
+def read_protocol_csv(path: str) -> pd.DataFrame:
+    """Load a protocol CSV file enforcing :data:`PROTOCOL_DTYPES`.
+
+    Parameters
+    ----------
+    path:
+        Location of the CSV file.
+    """
+
+    return pd.read_csv(path, dtype=PROTOCOL_DTYPES)

--- a/tests/test_io_schema.py
+++ b/tests/test_io_schema.py
@@ -1,0 +1,61 @@
+from dataclasses import asdict
+
+import pandas as pd
+from pandas.api.types import (
+    is_string_dtype,
+    is_integer_dtype,
+    is_float_dtype,
+)
+
+from assembly_diffusion.io import (
+    ProtocolRow,
+    PROTOCOL_COLUMNS,
+    PROTOCOL_DTYPES,
+    write_protocol_csv,
+    read_protocol_csv,
+)
+
+
+def test_protocol_csv_roundtrip(tmp_path):
+    rows = [
+        ProtocolRow(
+            id="mol1",
+            universe="S",
+            grammar="g1",
+            As_lower=1,
+            As_upper=2,
+            validity=0.5,
+            frequency=3.0,
+            d_min=0.1,
+        ),
+        ProtocolRow(
+            id="mol2",
+            universe="T",
+            grammar="g2",
+            As_lower=3,
+            As_upper=3,
+            validity=1.0,
+            frequency=1.5,
+            d_min=0.2,
+        ),
+    ]
+    path = tmp_path / "protocol.csv"
+    write_protocol_csv(path, rows)
+
+    # Column order check
+    df_plain = pd.read_csv(path)
+    assert list(df_plain.columns) == PROTOCOL_COLUMNS
+
+    # Type check with enforced schema
+    df = read_protocol_csv(path)
+    expected = pd.DataFrame([asdict(r) for r in rows]).astype(PROTOCOL_DTYPES)
+    pd.testing.assert_frame_equal(df, expected)
+
+    assert is_string_dtype(df["id"])
+    assert is_string_dtype(df["universe"])
+    assert is_string_dtype(df["grammar"])
+    assert is_integer_dtype(df["As_lower"])
+    assert is_integer_dtype(df["As_upper"])
+    assert is_float_dtype(df["validity"])
+    assert is_float_dtype(df["frequency"])
+    assert is_float_dtype(df["d_min"])


### PR DESCRIPTION
## Summary
- add I/O module for writing protocol CSVs with fixed schema and types
- provide reader helper and schema constants
- test round-trip through pandas ensuring column order and dtypes

## Testing
- `pytest tests/test_io_schema.py -q`


------
https://chatgpt.com/codex/tasks/task_b_689993758fec8322b00dd30e29b6b7d2