### PR TITLE
Add pipeline script skeletons with dry-run support

### DIFF
--- a/scripts/aggregate.py
+++ b/scripts/aggregate.py
@@ -1,0 +1,35 @@
+"""Aggregate results placeholder script.
+
+This thin wrapper will eventually collate outputs from earlier pipeline steps.
+The current implementation only supports a ``--dry-run`` flag for interface
+testing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Aggregate pipeline outputs")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show intended actions without executing",
+    )
+    args = parser.parse_args(argv)
+
+    if args.dry_run:
+        logger.info("Dry run: no action taken")
+        return 0
+
+    logger.info("Aggregation step is not yet implemented")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/scripts/compute_ai.py
+++ b/scripts/compute_ai.py
@@ -1,0 +1,35 @@
+"""Compute AI scores placeholder.
+
+This script is a stub for computing assembly indices.  The ``--dry-run`` option
+allows the command line interface to be exercised without executing any core
+logic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Compute assembly indices")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run without performing any computation",
+    )
+    args = parser.parse_args(argv)
+
+    if args.dry_run:
+        logger.info("Dry run: no action taken")
+        return 0
+
+    logger.info("AI computation is not yet implemented")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/scripts/fit_slope.py
+++ b/scripts/fit_slope.py
@@ -1,0 +1,34 @@
+"""Fit slope analysis placeholder.
+
+This command line entry point will eventually fit slopes to aggregated results.
+For now it only exposes a ``--dry-run`` option.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Fit slopes to results")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run without executing the fitting procedure",
+    )
+    args = parser.parse_args(argv)
+
+    if args.dry_run:
+        logger.info("Dry run: no action taken")
+        return 0
+
+    logger.info("Slope fitting is not yet implemented")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/scripts/plots.py
+++ b/scripts/plots.py
@@ -1,0 +1,34 @@
+"""Plot generation placeholder script.
+
+The plotting step will visualise results from the pipeline.  At present the
+script merely provides a ``--dry-run`` flag for interface testing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate diagnostic plots")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Run without creating any plots",
+    )
+    args = parser.parse_args(argv)
+
+    if args.dry_run:
+        logger.info("Dry run: no action taken")
+        return 0
+
+    logger.info("Plot generation is not yet implemented")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/scripts/sample.py
+++ b/scripts/sample.py
@@ -1,0 +1,44 @@
+"""Sample pipeline step wrapper.
+
+This thin script is a placeholder for the sampling stage of the diffusion
+assembly pipeline.  It intentionally avoids importing heavy dependencies so
+that the ``--dry-run`` flag can be used for quick CLI verification.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for the sample step.
+
+    Parameters
+    ----------
+    argv:
+        Optional list of command line arguments.  When ``None`` the arguments
+        are pulled from ``sys.argv``.
+    """
+
+    parser = argparse.ArgumentParser(description="Run the sampling step")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print actions without executing them",
+    )
+    args = parser.parse_args(argv)
+
+    if args.dry_run:
+        logger.info("Dry run: no action taken")
+        return 0
+
+    logger.info("Sampling step is not yet implemented")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add stub scripts for sampling, AI computation, aggregation, slope fitting, and plotting
- each script offers a `--dry-run` flag for CLI testing without touching model code

## Testing
- `pytest -q`
- `for s in sample compute_ai aggregate fit_slope plots; do python scripts/$s.py --dry-run; done`


------
https://chatgpt.com/codex/tasks/task_b_689993958aa8832288b16e3cac2785a3