### PR TITLE
Vendor AssemblyMC wrapper and documentation

### DIFF
--- a/extern/assemblymc/README.md
+++ b/extern/assemblymc/README.md
@@ -1,0 +1,36 @@
+# AssemblyMC Binary
+
+This directory vendors the `AssemblyMC` Monte Carlo solver from the Cronin Group's [Paper-AssemblyTreeOfLife](https://github.com/croningp/Paper-AssemblyTreeOfLife) project.
+
+## Obtaining the binary
+
+The upstream repository distributes a prebuilt Windows executable as `AssemblyMC.zip`. Download that file and rename it to `AssemblyMC.exe` **without unzipping**. Place the renamed executable **and the accompanying `libinchi.dll`** in the `bin/` directory beside this README. These files are not tracked in version control; you must obtain them from the upstream project.
+
+## Running
+
+On Windows, invoke the executable directly:
+
+```powershell
+AssemblyMC.exe --help
+```
+
+On Unix-like systems, install [Wine](https://www.winehq.org/) and use the wrapper script:
+
+```bash
+./AssemblyMC --help
+```
+
+The wrapper forwards all arguments to `AssemblyMC.exe` via `wine` and prints helpful instructions if Wine or the executable are missing.
+
+## Building from source
+
+1. Clone the upstream repository:
+   ```bash
+   git clone https://github.com/croningp/Paper-AssemblyTreeOfLife
+   ```
+2. The C++ sources live under `AssemblyMC_cpp_sc/`.
+3. Follow the upstream instructions to build with Visual Studio 2019 or later. The build expects the bundled InChI library found under `AssemblyMC_cpp_sc/INCHI_API`.
+
+## Permission and licensing
+
+The `AssemblyMC` binary is the intellectual property of the Cronin Group. Please consult the upstream project and obtain appropriate permission before using the executable in other contexts.

--- a/extern/assemblymc/bin/.gitignore
+++ b/extern/assemblymc/bin/.gitignore
@@ -1,0 +1,2 @@
+AssemblyMC.exe
+libinchi.dll

--- a/extern/assemblymc/bin/AssemblyMC
+++ b/extern/assemblymc/bin/AssemblyMC
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+DIR="$(cd "$(dirname "$0")" && pwd)"
+BIN="$DIR/AssemblyMC.exe"
+
+if [[ "$1" == "--help" ]]; then
+  echo "Wrapper for AssemblyMC.exe" >&2
+  echo "Download AssemblyMC.zip from the upstream project, rename it to AssemblyMC.exe, and place it alongside this script." >&2
+  echo "On non-Windows platforms this script uses Wine to execute the binary." >&2
+  if command -v wine >/dev/null 2>&1 && [[ -f "$BIN" ]]; then
+    exec wine "$BIN" --help
+  else
+    exit 0
+  fi
+fi
+
+if [[ ! -f "$BIN" ]]; then
+  echo "AssemblyMC.exe not found at $BIN" >&2
+  exit 1
+fi
+
+if command -v wine >/dev/null 2>&1; then
+  exec wine "$BIN" "$@"
+else
+  echo "AssemblyMC binary requires Wine on non-Windows platforms." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Document how to obtain `AssemblyMC.exe` and its `libinchi.dll` without shipping the binaries
- Improve wrapper script to guide users and fail gracefully when the executable is missing
- Ignore AssemblyMC binary artifacts in version control

## Testing
- `extern/assemblymc/bin/AssemblyMC --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_6899a6401eb883228f3dccefce58d213