### PR TITLE
feat: add SMILES canonicalization utilities

### DIFF
--- a/assembly_diffusion/__init__.py
+++ b/assembly_diffusion/__init__.py
@@ -18,4 +18,5 @@ __all__ = [
     "ai_mc",
     "assembly_index",
     "run_logger",
+    "canonicalize",
 ]

--- a/assembly_diffusion/canonicalize.py
+++ b/assembly_diffusion/canonicalize.py
@@ -1,0 +1,53 @@
+"""Utilities for canonicalising SMILES strings."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from typing import Tuple
+
+from rdkit import Chem
+from rdkit.Chem import inchi
+from rdkit.Chem.rdchem import Mol, MolSanitizeException
+
+__all__ = ["smiles_to_mol", "mol_to_smiles", "canonicalize_smiles"]
+
+
+def smiles_to_mol(smiles: str) -> Mol:
+    """Convert a SMILES string to an RDKit Mol.
+
+    Raises:
+        ValueError: If the SMILES string is invalid.
+    """
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        raise ValueError(f"Invalid SMILES: {smiles}")
+    try:
+        Chem.SanitizeMol(mol)
+    except (ValueError, RuntimeError, MolSanitizeException) as e:  # pragma: no cover - defensive
+        raise ValueError(f"Invalid SMILES: {smiles}") from e
+    return mol
+
+
+def mol_to_smiles(mol: Mol) -> str:
+    """Return the canonical SMILES representation of a molecule."""
+    return Chem.MolToSmiles(mol, isomericSmiles=True, canonical=True)
+
+
+def canonicalize_smiles(smiles: str) -> Tuple[str, str]:
+    """Return canonical SMILES and InChIKey for a SMILES string.
+
+    A temporary file is created during processing and removed afterwards to
+    ensure no artefacts are left on disk.
+    """
+    mol = smiles_to_mol(smiles)
+    canonical = mol_to_smiles(mol)
+    tmp = tempfile.NamedTemporaryFile("w", delete=False)
+    try:
+        tmp.write(canonical)
+        tmp.flush()
+        key = inchi.MolToInchiKey(mol)
+    finally:
+        tmp.close()
+        Path(tmp.name).unlink(missing_ok=True)
+    return canonical, key

--- a/tests/test_canonicalize_utils.py
+++ b/tests/test_canonicalize_utils.py
@@ -1,0 +1,30 @@
+import tempfile
+
+import pytest
+from rdkit import Chem
+from rdkit.Chem import inchi
+
+from assembly_diffusion.canonicalize import canonicalize_smiles
+
+
+def test_roundtrip_and_keying():
+    smi = "C1=CC=CC=C1"
+    expected_mol = Chem.MolFromSmiles(smi)
+    Chem.SanitizeMol(expected_mol)
+    expected_can = Chem.MolToSmiles(expected_mol, isomericSmiles=True, canonical=True)
+    expected_key = inchi.MolToInchiKey(expected_mol)
+    can, key = canonicalize_smiles(smi)
+    assert can == expected_can
+    assert key == expected_key
+
+
+def test_invalid_smiles_raises():
+    with pytest.raises(ValueError):
+        canonicalize_smiles("not a smiles")
+
+
+def test_tempfile_removed(tmp_path, monkeypatch):
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp_path))
+    canonicalize_smiles("CC")
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Summary
- add utilities to canonicalize SMILES, compute InChIKey, and clean temp files
- expose canonicalization module via package init
- test roundtrip, invalid SMILES, and temp file cleanup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6899ae5cbe988322a81f07177f308542