### PR TITLE
Add AssemblyMC hygiene guardrails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,51 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+.env/
+.env.bak/
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+htmlcov/
+.coverage*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# MacOS
+.DS_Store
+
+# VS Code
+.vscode/
+
+# AssemblyMC binaries and archives
+*AssemblyMC*
+*AssemblyMC*.zip
+*AssemblyMC*.exe
+
+# Experiment outputs
+results/

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ The QM9 dataset is downloaded on demand. By default files are stored in a
 SHA-256 checksum and corrupted archives trigger a clear error so they can be
 re-downloaded.
 
+### AssemblyMC binaries
+
+The project can interface with an optional `AssemblyMC` executable. This
+component is distributed separately and is intended for **local use only**.
+Do not commit any `AssemblyMC` binaries or archives to the repository; the
+included `.gitignore` prevents them from being tracked.
+
 ## Usage
 
 Once installed, the package exposes a small command line interface that can


### PR DESCRIPTION
## Summary
- ignore AssemblyMC binaries, archives and experiment outputs
- document that AssemblyMC binaries must remain local-only

## Testing
- `pytest`
- `git grep -i 'AssemblyMC'`
- `pip install -e .`


------
https://chatgpt.com/codex/tasks/task_b_6899ae30d54883229dab10dcfb26dfef