### PR TITLE
Record AssemblyMC provenance and document grammar parity

### DIFF
--- a/assembly_diffusion/run_logger.py
+++ b/assembly_diffusion/run_logger.py
@@ -5,6 +5,7 @@ import logging
 import random
 import subprocess
 import sys
+import platform
 from importlib import metadata
 from pathlib import Path
 from typing import Dict, Optional
@@ -72,9 +73,10 @@ def init_run_logger(
 ) -> logging.Logger:
     """Initialise a file logger that writes a JSON header.
 
-    The header contains RNG seeds, package versions, git commit hash, the
-    grammar label, and the configuration blob.  It is written to the log
-    file before any other records.
+    The header contains RNG seeds, package versions, git commit hash,
+    operating system details, the command line, the grammar label, and the
+    configuration blob.  It is written to the log file before any other
+    records.
     """
 
     if _RUN_LOGGER.handlers:
@@ -86,6 +88,8 @@ def init_run_logger(
         "seeds": seeds,
         "packages": _package_versions(),
         "git_hash": _git_hash(),
+        "windows_version": platform.platform(),
+        "command": " ".join(sys.argv),
         "grammar": grammar,
         "config": config,
     }

--- a/docs/grammar_parity.md
+++ b/docs/grammar_parity.md
@@ -1,0 +1,27 @@
+# Grammar parity and provenance
+
+AssemblyMC approximates the assembly index by repeatedly splitting a molecule
+into fragments.  Our diffusion grammar **G** grows molecules via bond edits and
+atom insertions.  The table below maps the concepts:
+
+| AssemblyMC step | Grammar production | Label |
+|-----------------|-------------------|-------|
+| Split fragment into two parts | Inverse of a bond edit in **G** | `G_MC`
+
+Because a Monte-Carlo step is not identical to any single production in **G**, runs
+that rely on the AssemblyMC estimator should be recorded with the grammar label
+`G_MC`.  If future work proves the operations to be exactly equivalent,
+`G` may be used instead.
+
+## Provenance logging
+
+When `ai.method=assemblymc`, the run logger captures additional
+information for reproducibility:
+
+- Commit hash of the local repository.
+- Windows/OS version.
+- Full command line used to invoke the program.
+
+This metadata is emitted in the JSON header produced by
+`assembly_diffusion.run_logger.init_run_logger`, enabling downstream
+consumers to trace the exact environment used for AssemblyMC results.

--- a/tests/test_run_logger.py
+++ b/tests/test_run_logger.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 
 from assembly_diffusion import run_logger
 
@@ -6,7 +7,7 @@ from assembly_diffusion import run_logger
 def test_run_log_contains_header(tmp_path):
     log_file = tmp_path / "run.log"
     cfg = {"alpha": 1}
-    logger = run_logger.init_run_logger(str(log_file), grammar="G", config=cfg, seed=42)
+    logger = run_logger.init_run_logger(str(log_file), grammar="G_MC", config=cfg, seed=42)
     logger.info("run start")
     lines = log_file.read_text().splitlines()[:5]
     header = None
@@ -17,7 +18,22 @@ def test_run_log_contains_header(tmp_path):
         except json.JSONDecodeError:
             continue
     assert header is not None
-    for key in ["seeds", "packages", "git_hash", "grammar", "config"]:
+    for key in [
+        "seeds",
+        "packages",
+        "git_hash",
+        "grammar",
+        "config",
+        "command",
+        "windows_version",
+    ]:
         assert key in header
-    assert header["grammar"] == "G"
+
+    expected_hash = (
+        subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    )
+    assert header["git_hash"] == expected_hash
+    assert header["grammar"] == "G_MC"
     assert header["config"] == cfg
+    assert header["command"]
+    assert header["windows_version"]


### PR DESCRIPTION
## Summary
- document mapping between AssemblyMC steps and grammar G, noting when to use the `G_MC` label
- record OS version, command line and commit hash in `init_run_logger`
- expand run logger test to check provenance fields and commit hash

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6899ae78c840832285215da247adedb9