### PR TITLE
Narrow overly broad exception handling

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -49,7 +49,7 @@ def _log_environment(seed: int = 0) -> None:
     np.random.seed(seed)
     try:
         commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
-    except Exception:  # pragma: no cover - git may be unavailable
+    except (subprocess.CalledProcessError, OSError):  # pragma: no cover - git may be unavailable
         commit = "unknown"
     logger.info(
         "Reproducibility: seed=%s python=%s numpy=%s pandas=%s scipy=%s statsmodels=%s commit=%s",

--- a/assembly_diffusion/ai_mc.py
+++ b/assembly_diffusion/ai_mc.py
@@ -49,7 +49,7 @@ def _brics_cuts(mol: "Chem.Mol") -> List[Tuple[int, int]]:
                 brics.append((i, j))
             if brics:
                 bonds = brics
-        except Exception:  # pragma: no cover - defensive against RDKit issues
+        except (ValueError, RuntimeError):  # pragma: no cover - defensive against RDKit issues
             pass
     return bonds
 

--- a/assembly_diffusion/eval/metrics.py
+++ b/assembly_diffusion/eval/metrics.py
@@ -78,7 +78,7 @@ def _configure_reproducibility(seed: int) -> None:
         import numpy as np  # type: ignore
 
         np.random.seed(seed)
-    except Exception:  # pragma: no cover - optional dependency
+    except ImportError:  # pragma: no cover - optional dependency
         pass
     try:
         import torch  # type: ignore
@@ -86,7 +86,7 @@ def _configure_reproducibility(seed: int) -> None:
         torch.manual_seed(seed)
         if torch.cuda.is_available():  # pragma: no cover - GPU optional
             torch.cuda.manual_seed_all(seed)
-    except Exception:  # pragma: no cover - optional dependency
+    except ImportError:  # pragma: no cover - optional dependency
         pass
 
     logger.info("Random seed set to %d", seed)

--- a/assembly_diffusion/eval/run_smoketest.py
+++ b/assembly_diffusion/eval/run_smoketest.py
@@ -67,7 +67,7 @@ def main() -> None:
     np.random.seed(0)
     try:
         commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
-    except Exception:  # pragma: no cover - git may be unavailable
+    except (subprocess.CalledProcessError, OSError):  # pragma: no cover - git may be unavailable
         commit = "unknown"
     logger.info(
         "Reproducibility: seed=%s python=%s numpy=%s commit=%s",

--- a/assembly_diffusion/eval/validity.py
+++ b/assembly_diffusion/eval/validity.py
@@ -70,7 +70,7 @@ def configure_reproducibility(seed: int) -> None:
         import numpy as np  # type: ignore
 
         np.random.seed(seed)
-    except Exception:  # pragma: no cover - optional dependency
+    except ImportError:  # pragma: no cover - optional dependency
         pass
     try:
         import torch  # type: ignore
@@ -78,7 +78,7 @@ def configure_reproducibility(seed: int) -> None:
         torch.manual_seed(seed)
         if torch.cuda.is_available():  # pragma: no cover - GPU optional
             torch.cuda.manual_seed_all(seed)
-    except Exception:  # pragma: no cover - optional dependency
+    except ImportError:  # pragma: no cover - optional dependency
         pass
 
     logger.info("Random seed set to %d", seed)

--- a/assembly_diffusion/extern/assemblymc.py
+++ b/assembly_diffusion/extern/assemblymc.py
@@ -97,7 +97,7 @@ def _resolve_bin() -> Path:
         cfg_bin = getattr(getattr(_config, "ai", object()), "bin_path", None)
         if cfg_bin:
             return Path(cfg_bin)
-    except Exception:
+    except (ImportError, AttributeError):
         pass
     raise AssemblyMCError(
         "AssemblyMC binary not configured. Obtain permission, compile the binary, "

--- a/assembly_diffusion/qed_sa.py
+++ b/assembly_diffusion/qed_sa.py
@@ -14,7 +14,7 @@ except ImportError:  # pragma: no cover - handled at runtime
 
 try:  # pragma: no cover - optional SA scorer
     from .sascorer import calculateScore as sa_score
-except Exception:  # pragma: no cover - handled at runtime
+except ImportError:  # pragma: no cover - handled at runtime
     sa_score = None
 
 _HAVE_QED = Chem is not None and QED is not None

--- a/assembly_diffusion/repro.py
+++ b/assembly_diffusion/repro.py
@@ -11,22 +11,22 @@ import numpy as np
 
 try:  # Optional dependencies; versions logged if installed
     import pandas as pd
-except Exception:  # pragma: no cover - pandas may be absent
+except ImportError:  # pragma: no cover - pandas may be absent
     pd = None  # type: ignore
 
 try:
     import scipy
-except Exception:  # pragma: no cover - scipy may be absent
+except ImportError:  # pragma: no cover - scipy may be absent
     scipy = None  # type: ignore
 
 try:
     import statsmodels
-except Exception:  # pragma: no cover - statsmodels may be absent
+except ImportError:  # pragma: no cover - statsmodels may be absent
     statsmodels = None  # type: ignore
 
 try:
     import torch
-except Exception:  # pragma: no cover - torch may be absent
+except ImportError:  # pragma: no cover - torch may be absent
     torch = None  # type: ignore
 
 
@@ -48,7 +48,7 @@ def setup_reproducibility(seed: int = 0) -> None:
 
     try:
         commit = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
-    except Exception:  # pragma: no cover - git may be unavailable
+    except (subprocess.CalledProcessError, OSError):  # pragma: no cover - git may be unavailable
         commit = "unknown"
 
     logger = logging.getLogger(__name__)

--- a/assembly_diffusion/run_logger.py
+++ b/assembly_diffusion/run_logger.py
@@ -28,7 +28,7 @@ def _git_hash() -> str:
             .decode()
             .strip()
         )
-    except Exception:
+    except (subprocess.CalledProcessError, OSError):
         return "unknown"
 
 
@@ -53,14 +53,14 @@ def _set_seeds(seed: int) -> Dict[str, int]:
 
         np.random.seed(seed)
         seeds["numpy"] = seed
-    except Exception:
+    except ImportError:
         pass
     try:  # Optional torch seed
         import torch  # type: ignore
 
         torch.manual_seed(seed)
         seeds["torch"] = seed
-    except Exception:
+    except ImportError:
         pass
     return seeds
 
@@ -77,7 +77,7 @@ def reset_run_logger() -> None:
         _RUN_LOGGER.removeHandler(handler)
         try:
             handler.close()
-        except Exception:
+        except OSError:
             pass
 
 

--- a/assembly_diffusion/train.py
+++ b/assembly_diffusion/train.py
@@ -67,7 +67,7 @@ def setup_reproducibility(seed: int) -> None:
             for d in importlib_metadata.distributions()
         )
         logger.info("Package versions:\n%s", "\n".join(packages))
-    except Exception as exc:  # pragma: no cover - best effort
+    except (importlib_metadata.PackageNotFoundError, OSError, KeyError) as exc:  # pragma: no cover - best effort
         logger.warning("Failed to list package versions: %s", exc)
 
     try:
@@ -76,7 +76,7 @@ def setup_reproducibility(seed: int) -> None:
             ["git", "rev-parse", "HEAD"], cwd=repo_root, text=True
         ).strip()
         logger.info("Git commit SHA: %s", commit)
-    except Exception as exc:  # pragma: no cover - best effort
+    except (subprocess.CalledProcessError, OSError) as exc:  # pragma: no cover - best effort
         logger.warning("Failed to obtain git commit SHA: %s", exc)
 
 

--- a/scripts/train_surrogate.py
+++ b/scripts/train_surrogate.py
@@ -58,7 +58,7 @@ def _load_labels(csv_path: str) -> np.ndarray:
         y = df.get("ai_exact")
         if y is not None and len(y) > 0:
             return y.to_numpy(dtype=float)
-    except Exception:  # pragma: no cover - file may be missing/empty
+    except (OSError, pd.errors.EmptyDataError):  # pragma: no cover - file may be missing/empty
         logger.warning("Could not load %s; using synthetic labels", csv_path)
     return np.array([0.0, 1.0, 2.0], dtype=float)
 


### PR DESCRIPTION
## Summary
- Replace blanket `except Exception` handlers with targeted exceptions across utility modules
- Tighten optional import handling for reproducibility and logging helpers
- Guard RDKit BRICS calls against explicit runtime and value errors

## Testing
- `git grep -n "except:"`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6899c0e2fe80832297425936282b2401