### PR TITLE
Handle deprecated exact AI method

### DIFF
--- a/assembly_diffusion/config.py
+++ b/assembly_diffusion/config.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, get_type_hints
 
+import warnings
 import yaml
 
 
@@ -106,8 +107,16 @@ def load_run_config(path: str | Path) -> RunConfig:
     seeds = [int(s) for s in (seeds_raw if isinstance(seeds_raw, list) else [seeds_raw])]
 
     ai_raw = raw.get("ai", {})
+    method = str(ai_raw.get("method", "surrogate"))
+    if method == "exact":
+        warnings.warn(
+            "ai.method='exact' is deprecated; use 'assemblymc' instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        method = "assemblymc"
     ai_cfg = AIConfig(
-        method=str(ai_raw.get("method", "surrogate")),
+        method=method,
         trials=int(ai_raw.get("trials", 1)),
         timeout_s=float(ai_raw.get("timeout_s", 0.0)),
     )

--- a/tests/test_run_config.py
+++ b/tests/test_run_config.py
@@ -1,3 +1,5 @@
+import pytest
+
 from assembly_diffusion.config import load_run_config
 from assembly_diffusion.cli import build_ai
 
@@ -24,5 +26,15 @@ def test_ai_method_toggle(tmp_path):
 
     _write_cfg(cfg_path, "assemblymc")
     cfg = load_run_config(cfg_path)
+    ai = build_ai(cfg.ai.method)
+    assert ai.__class__.__name__ == "AssemblyMC"
+
+
+def test_ai_method_exact_warns(tmp_path):
+    cfg_path = tmp_path / "run.yml"
+    _write_cfg(cfg_path, "exact")
+    with pytest.warns(DeprecationWarning) as w:
+        cfg = load_run_config(cfg_path)
+    assert len(w) == 1
     ai = build_ai(cfg.ai.method)
     assert ai.__class__.__name__ == "AssemblyMC"


### PR DESCRIPTION
## Summary
- map deprecated `ai.method=exact` to `assemblymc` in run configs
- warn once when legacy value is used
- test that legacy configs still run via AssemblyMC

## Testing
- `pytest tests/test_run_config.py -q`
- `pytest tests/test_config_loader.py -q`


------
https://chatgpt.com/codex/tasks/task_b_6899c10293748322917f994992d457f1