### PR TITLE
Add compute_ai facade with AssemblyMC fallback

### DIFF
--- a/assembly_diffusion/__init__.py
+++ b/assembly_diffusion/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "ai_surrogate",
     "ai_mc",
     "assembly_index",
+    "compute_ai",
     "run_logger",
     "canonicalize",
 ]

--- a/assembly_diffusion/compute_ai.py
+++ b/assembly_diffusion/compute_ai.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""Facade for computing assembly index bounds.
+
+This module exposes :func:`compute_ai` which evaluates the assembly index for
+``MoleculeGraph`` instances using either a fast surrogate or the external
+AssemblyMC solver.  The behaviour is controlled via ``method`` which mirrors
+``ai.method`` from the run configuration.
+
+* ``method="surrogate"`` – return a pair ``(As_lower, As_upper)`` computed via
+  inexpensive graph heuristics.
+* ``method="assemblymc"`` – call the AssemblyMC binary to obtain the exact
+  assembly index ``A_star``.  The lower and upper bounds are both set to this
+  value.
+
+When ``method="assemblymc"`` but the required ``ASSEMBLYMC_BIN`` environment
+variable is not defined, the function raises :class:`AssemblyMCError` unless
+``allow_fallback`` is set.  In the latter case the surrogate bounds are
+returned instead.
+"""
+
+from typing import Tuple
+
+from .graph import MoleculeGraph
+from .assembly_index import AssemblyIndex, approx_AI
+
+
+def _surrogate_bounds(graph: MoleculeGraph) -> Tuple[int, int]:
+    """Return heuristic lower and upper bounds for ``graph``.
+
+    The lower bound is based on a cycle count and the upper bound uses the
+    fragment based approximation.  The upper bound is never smaller than the
+    lower bound.
+    """
+
+    lower = AssemblyIndex.A_lower_bound(graph)
+    upper = max(lower, approx_AI(graph))
+    return int(lower), int(upper)
+
+
+def compute_ai(
+    graph: MoleculeGraph,
+    method: str = "surrogate",
+    allow_fallback: bool = False,
+) -> Tuple[int, int]:
+    """Compute assembly index bounds for ``graph``.
+
+    Parameters
+    ----------
+    graph:
+        Molecule graph to evaluate.
+    method:
+        ``"surrogate"`` or ``"assemblymc"``.
+    allow_fallback:
+        When ``True`` and ``method="assemblymc"`` but the AssemblyMC binary is
+        unavailable, the surrogate bounds are returned instead of raising.
+
+    Returns
+    -------
+    Tuple[int, int]
+        ``(As_lower, As_upper)`` bounds on the assembly index.
+    """
+
+    if method == "surrogate":
+        return _surrogate_bounds(graph)
+
+    if method == "assemblymc":
+        try:
+            from rdkit import Chem  # type: ignore
+            from .extern.assemblymc import a_star_and_dmin, AssemblyMCError
+
+            mol = graph.to_rdkit()
+            smiles = Chem.MolToSmiles(mol, canonical=True)
+            a_star, _, _ = a_star_and_dmin(smiles)
+            return int(a_star), int(a_star)
+        except Exception as exc:  # pragma: no cover - error path
+            # Catch both AssemblyMCError and ImportError from RDKit
+            from .extern.assemblymc import AssemblyMCError
+
+            if allow_fallback:
+                return _surrogate_bounds(graph)
+            if isinstance(exc, AssemblyMCError):
+                raise
+            raise AssemblyMCError(str(exc)) from exc
+
+    raise ValueError(f"Unknown ai.method '{method}'")

--- a/tests/test_compute_ai.py
+++ b/tests/test_compute_ai.py
@@ -1,0 +1,63 @@
+import os
+from pathlib import Path
+
+import torch
+import pytest
+
+from assembly_diffusion.graph import MoleculeGraph
+from assembly_diffusion.compute_ai import compute_ai
+from assembly_diffusion.assembly_index import AssemblyIndex, approx_AI
+import assembly_diffusion.extern.assemblymc as amc
+from assembly_diffusion.extern.assemblymc import AssemblyMCError
+
+
+def _simple_graph() -> MoleculeGraph:
+    atoms = ["C"]
+    bonds = torch.zeros((1, 1), dtype=torch.int64)
+    return MoleculeGraph(atoms, bonds)
+
+
+def _dummy_binary(path: Path) -> Path:
+    script = path / "dummy_assemblymc.py"
+    script.write_text(
+        """#!/usr/bin/env python3
+import json, sys
+smiles = sys.argv[1]
+print(f'A_star: {len(smiles)}')
+print('d_min_est: 0')
+with open('stats.json', 'w') as f:
+    json.dump({}, f)
+"""
+    )
+    script.chmod(0o755)
+    return script
+
+
+def test_surrogate_bounds():
+    g = _simple_graph()
+    lower, upper = compute_ai(g, method="surrogate")
+    assert lower <= upper
+
+
+def test_assemblymc_bounds(monkeypatch, tmp_path):
+    g = _simple_graph()
+    bin_path = _dummy_binary(tmp_path)
+    cache_dir = tmp_path / "cache"
+    monkeypatch.setenv("ASSEMBLYMC_BIN", str(bin_path))
+    monkeypatch.setenv("ASSEMBLYMC_CACHE", str(cache_dir))
+    lower, upper = compute_ai(g, method="assemblymc")
+    assert lower == upper == 1
+
+
+def test_assemblymc_missing_env(monkeypatch):
+    g = _simple_graph()
+    amc._CACHE.clear()
+    monkeypatch.delenv("ASSEMBLYMC_BIN", raising=False)
+    with pytest.raises(AssemblyMCError):
+        compute_ai(g, method="assemblymc")
+    lower, upper = compute_ai(g, method="assemblymc", allow_fallback=True)
+    assert lower <= upper
+    # Ensure fallback matches surrogate computation
+    s_lower = AssemblyIndex.A_lower_bound(g)
+    s_upper = max(s_lower, approx_AI(g))
+    assert (lower, upper) == (s_lower, s_upper)


### PR DESCRIPTION
## Summary
- add `compute_ai` helper to produce assembly index bounds via surrogate heuristics or AssemblyMC
- export `compute_ai` in module `__all__`
- cover AssemblyMC/Surrogate behavior and fallback logic with dedicated tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689a348884f08322ac644d316b0a045f