### PR TITLE
Implement baseline slope fitting with bootstrap

### DIFF
--- a/scripts/fit_slope.py
+++ b/scripts/fit_slope.py
@@ -1,33 +1,57 @@
-"""Fit slope analysis placeholder.
+"""Fit slope analysis for unguided baseline samples.
 
-This command line entry point will eventually fit slopes to aggregated results.
-For now it only exposes a ``--dry-run`` option.
+This command fits a log-frequency vs. assembly index slope for a column ``A``
+contained in a CSV file.  A bootstrap distribution of slope estimates is saved
+to ``--out``.
 """
-
 from __future__ import annotations
 
 import argparse
 import logging
 
+import pandas as pd
+
+from analysis import baseline_slope_fit
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
 def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser(description="Fit slopes to results")
+    parser = argparse.ArgumentParser(description="Fit baseline slope")
+    parser.add_argument("csv", help="CSV file with column of assembly indices")
     parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Run without executing the fitting procedure",
+        "--column",
+        default="A",
+        help="Name of column containing assembly indices",
+    )
+    parser.add_argument("--alpha", type=float, default=0.05, help="Significance level")
+    parser.add_argument("--boot", type=int, default=1000, help="Bootstrap iterations")
+    parser.add_argument(
+        "--out",
+        type=str,
+        default="bootstrap.npy",
+        help="Path to save bootstrap slope estimates",
     )
     args = parser.parse_args(argv)
 
-    if args.dry_run:
-        logger.info("Dry run: no action taken")
-        return 0
-
-    logger.info("Slope fitting is not yet implemented")
+    df = pd.read_csv(args.csv)
+    if args.column not in df:
+        raise KeyError(f"Column {args.column} not found in {args.csv}")
+    values = df[args.column].to_numpy()
+    result = baseline_slope_fit(
+        values,
+        alpha=args.alpha,
+        n_boot=args.boot,
+        save_bootstrap=args.out,
+    )
+    logger.info(
+        "m=%f 95%% CI=[%f, %f] saved=%s",
+        result["m"],
+        result["ci_lo"],
+        result["ci_hi"],
+        args.out,
+    )
     return 0
 
 

--- a/tests/test_fit_slope.py
+++ b/tests/test_fit_slope.py
@@ -1,0 +1,16 @@
+"""Tests for baseline_slope_fit utility."""
+import numpy as np
+
+from analysis import baseline_slope_fit
+
+
+def test_baseline_slope_fit(tmp_path):
+    rng = np.random.default_rng(0)
+    # Generate 6000 samples from a Poisson distribution with mean 10
+    samples = rng.poisson(lam=10, size=6000)
+    out_path = tmp_path / "boots.npy"
+    res = baseline_slope_fit(samples, n_boot=200, save_bootstrap=str(out_path), random_state=0)
+    assert res["m"] < 0
+    assert res["ci_hi"] < 0
+    data = np.load(out_path)
+    assert data.shape[0] == 200


### PR DESCRIPTION
## Summary
- add `baseline_slope_fit` utility for trimmed OLS with bootstrap CI and artifact saving
- expose CLI `scripts/fit_slope.py` to fit slopes from CSV data
- test slope fitting on synthetic data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689a34c3c00883228e5a53b01550d145