### PR TITLE
Add metrics aggregation utility with CSV output and tests

### DIFF
--- a/assembly_diffusion/eval/metrics_aggregator.py
+++ b/assembly_diffusion/eval/metrics_aggregator.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+"""Utilities to aggregate evaluation metrics into CSV summaries.
+
+baseline: simple molecule sets provide a sanity check for metric aggregation.
+method: compute RDKit-based metrics for each named sample set and record counts
+    such as valid and unique molecules.  Results are written as CSV rows.
+objective: enable batch evaluation of multiple runs or baselines with
+    reproducible metrics.
+params: mapping of set names to ``MoleculeGraph`` sequences, reference SMILES,
+    output CSV path and random seed.
+repro: deterministic operations mirror those in :mod:`assembly_diffusion.eval.metrics`.
+validation: ``tests/test_metrics_aggregator.py`` exercises the aggregator on a
+    toy dataset, ensuring validity is in [0,1], counts sum correctly and
+    uniqueness/novelty ratios fall within expected bounds.
+"""
+
+from pathlib import Path
+import csv
+from typing import Iterable, Mapping, Sequence, Dict, Any, List
+
+from .metrics import Metrics, smiles_set
+from .validity import sanitize_or_none
+from ..graph import MoleculeGraph
+
+
+def aggregate_metrics(
+    sample_sets: Mapping[str, Sequence[MoleculeGraph]],
+    reference_smiles: Iterable[str],
+    out_csv: str | Path,
+    seed: int = 0,
+) -> List[Dict[str, Any]]:
+    """Evaluate ``sample_sets`` and write a CSV summary.
+
+    Parameters
+    ----------
+    sample_sets:
+        Mapping from set name to sequence of ``MoleculeGraph`` objects.
+    reference_smiles:
+        SMILES strings used as novelty reference.
+    out_csv:
+        Destination CSV file.  Parent directories are created if necessary.
+    seed:
+        Random seed forwarded to :func:`Metrics.evaluate`.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        List of metric rows written to ``out_csv``.
+    """
+
+    rows: List[Dict[str, Any]] = []
+    ref_set = set(reference_smiles)
+
+    for name, graphs in sample_sets.items():
+        metrics = Metrics.evaluate(graphs, ref_set, seed=seed)
+
+        total = len(graphs)
+        num_valid = sum(1 for g in graphs if sanitize_or_none(g) is not None)
+        unique_smiles = smiles_set(graphs)
+        num_unique = len(unique_smiles)
+        num_novel = sum(1 for s in unique_smiles if s not in ref_set)
+
+        row: Dict[str, Any] = {
+            "name": name,
+            "n_total": total,
+            "n_valid": num_valid,
+            "n_invalid": total - num_valid,
+            "n_unique": num_unique,
+            "n_novel": num_novel,
+            **metrics,
+        }
+        rows.append(row)
+
+    if rows:
+        out_path = Path(out_csv)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with out_path.open("w", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+            writer.writeheader()
+            writer.writerows(rows)
+
+    return rows

--- a/tests/test_metrics_aggregator.py
+++ b/tests/test_metrics_aggregator.py
@@ -1,0 +1,44 @@
+"""Tests for the metrics aggregator utility.
+
+baseline: simple molecule sets provide deterministic metric counts.
+validation: ensures validity ratios lie in [0,1], counts sum to the total
+    number of molecules and uniqueness/novelty ratios are well behaved. Also
+    checks that rows are emitted to the requested CSV file.
+"""
+
+import pandas as pd
+import pytest
+from rdkit import Chem
+import torch
+
+from assembly_diffusion.graph import MoleculeGraph
+from assembly_diffusion.eval.metrics_aggregator import aggregate_metrics
+
+
+def _valid(smiles: str) -> MoleculeGraph:
+    return MoleculeGraph.from_rdkit(Chem.MolFromSmiles(smiles))
+
+
+def _invalid() -> MoleculeGraph:
+    bonds = torch.tensor([[0, 4], [4, 0]], dtype=torch.int64)
+    return MoleculeGraph(["C", "C"], bonds)
+
+
+@pytest.mark.skipif(Chem is None, reason="RDKit not installed")
+def test_aggregate_metrics(tmp_path):
+    graphs = [_valid("C"), _invalid(), _valid("O")]
+    reference = ["C"]
+    out_csv = tmp_path / "metrics.csv"
+
+    rows = aggregate_metrics({"run": graphs}, reference, out_csv)
+
+    assert out_csv.exists()
+    df = pd.read_csv(out_csv)
+    assert df.shape[0] == 1
+
+    row = rows[0]
+    assert 0.0 <= row["validity"] <= 1.0
+    assert row["n_total"] == len(graphs)
+    assert row["n_valid"] + row["n_invalid"] == row["n_total"]
+    assert 0.0 <= row["uniqueness"] <= 1.0
+    assert 0.0 <= row["novelty"] <= 1.0


### PR DESCRIPTION
## Summary
- add `aggregate_metrics` helper to compute RDKit metrics and counts for multiple sample sets
- write aggregated metrics to CSV for downstream analysis
- cover metrics aggregator with a toy dataset test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689a34b0906083229b25b238b1ea0a7e