### PR TITLE
Add guided vs unguided reporting utility

### DIFF
--- a/assembly_diffusion/eval/reporting.py
+++ b/assembly_diffusion/eval/reporting.py
@@ -1,0 +1,81 @@
+"""Side-by-side reporting for guided vs unguided metrics.
+
+baseline: unguided diffusion metrics provide the reference for comparison
+    against guided runs.
+data_sources: metric dictionaries containing slope ``m`` with confidence
+    interval, validity fraction, and survival function ``S(A)`` values.
+method: write a combined JSON and Markdown report comparing guided and
+    unguided metrics side-by-side. The function logs the report paths using
+    ``assembly_diffusion.run_logger`` so that run logs reference the outputs.
+objective: simplify downstream analysis by storing a machine-readable JSON
+    summary and a human-friendly Markdown table in the same directory.
+params: ``outdir`` destination directory, ``guided`` and ``unguided`` metric
+    dictionaries.
+repro: output is deterministic given the metric inputs.
+validation: :mod:`tests.test_reporting` covers JSON/Markdown contents and log
+    references.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import logging
+from typing import Any, Dict, Tuple
+
+
+def _fmt_ci(ci: Any) -> str:
+    """Return a string representation of a confidence interval."""
+    if not ci:
+        return "N/A"
+    if isinstance(ci, (list, tuple)) and len(ci) == 2:
+        return f"[{ci[0]:.3f}, {ci[1]:.3f}]"
+    return str(ci)
+
+
+def write_guided_unguided_report(
+    outdir: str, guided: Dict[str, Any], unguided: Dict[str, Any]
+) -> Tuple[str, str]:
+    """Write side-by-side JSON and Markdown reports.
+
+    Parameters
+    ----------
+    outdir:
+        Directory in which the reports will be written. Created if necessary.
+    guided, unguided:
+        Metric dictionaries for the guided and unguided runs respectively.
+
+    Returns
+    -------
+    tuple of str
+        Paths to the JSON and Markdown files.
+    """
+
+    payload = {"guided": guided, "unguided": unguided}
+    os.makedirs(outdir, exist_ok=True)
+    json_path = os.path.join(outdir, "guided_vs_unguided.json")
+    md_path = os.path.join(outdir, "guided_vs_unguided.md")
+
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+
+    rows = [
+        ("m", guided.get("m"), unguided.get("m")),
+        ("CI", _fmt_ci(guided.get("CI")), _fmt_ci(unguided.get("CI"))),
+        ("validity", guided.get("validity"), unguided.get("validity")),
+        ("S(A)", guided.get("S(A)"), unguided.get("S(A)")),
+    ]
+    md_lines = ["| Metric | Guided | Unguided |", "|---|---|---|"]
+    for label, gv, uv in rows:
+        md_lines.append(f"| {label} | {gv} | {uv} |")
+    with open(md_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(md_lines) + "\n")
+
+    logger = logging.getLogger("assembly_diffusion.run")
+    logger.info("wrote guided_vs_unguided report to %s", json_path)
+    logger.info("wrote guided_vs_unguided report to %s", md_path)
+
+    return json_path, md_path
+
+
+__all__ = ["write_guided_unguided_report"]

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+
+from assembly_diffusion.run_logger import init_run_logger, reset_run_logger
+from assembly_diffusion.eval.reporting import write_guided_unguided_report
+
+
+def test_write_guided_unguided_report(tmp_path):
+    log_path = tmp_path / "run.log"
+    init_run_logger(str(log_path), "G", {})
+    guided = {"m": 1.2, "CI": [1.0, 1.4], "validity": 0.9, "S(A)": 0.1}
+    unguided = {"m": 0.8, "CI": [0.5, 1.0], "validity": 0.85, "S(A)": 0.2}
+    json_p, md_p = write_guided_unguided_report(str(tmp_path), guided, unguided)
+
+    data = json.loads(Path(json_p).read_text())
+    assert data["guided"]["m"] == 1.2
+    assert data["unguided"]["validity"] == 0.85
+
+    md = Path(md_p).read_text()
+    assert "| m | 1.2 | 0.8 |" in md
+    assert "| S(A) | 0.1 | 0.2 |" in md
+
+    log_text = log_path.read_text()
+    assert "guided_vs_unguided.json" in log_text
+    assert "guided_vs_unguided.md" in log_text
+    reset_run_logger()


### PR DESCRIPTION
## Summary
- add reporting helper writing guided vs unguided metrics to JSON and Markdown
- log report locations through run logger for provenance
- test report content and logging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689a63678d84832285c2179131960158