### PR TITLE
Clamp guidance lambda schedule to valid step range

### DIFF
--- a/assembly_diffusion/guidance.py
+++ b/assembly_diffusion/guidance.py
@@ -116,10 +116,19 @@ def additive_guidance(logits: Tensor, A_hat: Tensor, lam: float) -> Tensor:
 
 
 def linear_lambda_schedule(step: int, total_steps: int, lambda_max: float) -> float:
-    """Linearly ramp ``λ`` from ``0`` to ``lambda_max`` over diffusion steps."""
+    """Linearly ramp ``λ`` from ``0`` to ``lambda_max`` over diffusion steps.
+
+    The ``step`` value is clamped to ``[0, total_steps - 1]`` to provide a
+    simple guardrail against out-of-range inputs.
+    """
 
     if total_steps <= 1:
         return float(lambda_max)
+
+    # Clamp step to the valid range. This ensures callers that accidentally
+    # provide a step outside ``[0, total_steps - 1]`` receive a sensible value
+    # rather than extrapolating beyond the intended schedule.
+    step = max(0, min(step, total_steps - 1))
     return float(lambda_max) * step / (total_steps - 1)
 
 

--- a/docs/03_guidance.md
+++ b/docs/03_guidance.md
@@ -8,7 +8,9 @@ $$\log \hat{p}(a\mid s) = \log p_\theta(a\mid s) - \lambda\,\hat{A}(s \oplus a)$
 where $\hat{A}$ is the approximate assembly index of the successor state and
 $\lambda$ is a non-negative weight. During diffusion sampling $\lambda$ is
 increased linearly from $0$ to $\lambda_{\max}$ across the $T$ diffusion steps.
+The helper `linear_lambda_schedule` also clamps the requested step to the valid
+range, providing a guardrail against out-of-bounds inputs.
 
 The function `additive_guidance` in `assembly_diffusion.guidance` applies the
 above transformation, and `linear_lambda_schedule` provides the step-dependent
-$\lambda_t = \lambda_{\max}\, t/(T-1)$ schedule.
+$\lambda_t = \lambda_{\max}\, t/(T-1)$ schedule with this guardrail.

--- a/tests/test_guidance.py
+++ b/tests/test_guidance.py
@@ -57,3 +57,13 @@ def test_additive_guidance_monotone():
         probs.append(torch.softmax(new_logits, dim=-1)[0].item())
 
     assert probs[0] < probs[1] < probs[2]
+
+
+def test_linear_lambda_schedule_guardrail():
+    """Steps outside the valid range should be clamped."""
+
+    # Negative step clamps to 0
+    assert linear_lambda_schedule(-1, 3, 1.0) == 0.0
+
+    # Steps beyond the final diffusion step clamp to lambda_max
+    assert linear_lambda_schedule(5, 3, 1.0) == 1.0


### PR DESCRIPTION
## Summary
- clamp `linear_lambda_schedule` step within `[0, total_steps-1]` for safety
- document the schedule guardrail
- test clamping behavior in `test_guidance`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689a68fe6b948322adb01c3fc2800f30