### PR TITLE
Add d_min summary utilities and script

### DIFF
--- a/assembly_diffusion/calibrators/__init__.py
+++ b/assembly_diffusion/calibrators/__init__.py
@@ -1,0 +1,4 @@
+from .sampler import Sampler
+from .dmin_summary import summarize_dmin
+
+__all__ = ["Sampler", "summarize_dmin"]

--- a/assembly_diffusion/calibrators/dmin_summary.py
+++ b/assembly_diffusion/calibrators/dmin_summary.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Utilities for summarizing d_min estimates from calibrator runs."""
+
+from typing import Tuple
+
+import pandas as pd
+from scipy.stats import spearmanr
+
+
+def summarize_dmin(df: pd.DataFrame) -> Tuple[pd.DataFrame, float]:
+    """Return per-``A`` Spearman stats and fraction of non-null ``d_min``.
+
+    Parameters
+    ----------
+    df:
+        DataFrame with at least ``As_upper``, ``d_min`` and ``frequency`` columns.
+
+    Returns
+    -------
+    summary, frac
+        ``summary`` contains ``A``, Spearman ``rho``/``p`` and group sizes ``n``.
+        ``frac`` is the fraction of rows where ``d_min`` is not null.
+    """
+
+    frac = float(df["d_min"].notna().mean())
+    sub = df.dropna(subset=["d_min"]).copy()
+    sub["A"] = sub["As_upper"].astype(int)
+    rows = []
+    for A, g in sub.groupby("A"):
+        if g["d_min"].nunique() > 1 and g.shape[0] >= 4:
+            rho, p = spearmanr(g["frequency"], g["d_min"])
+            rows.append({"A": int(A), "rho": float(rho), "p": float(p), "n": int(g.shape[0])})
+    summary = pd.DataFrame(rows).sort_values("A").reset_index(drop=True)
+    return summary, frac

--- a/scripts/summarize_dmin.py
+++ b/scripts/summarize_dmin.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+import pandas as pd
+
+# Ensure project root on path when executed as script
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from assembly_diffusion.calibrators.dmin_summary import summarize_dmin
+
+
+parser = argparse.ArgumentParser(description="Summarize d_min estimates from calibrator outputs")
+parser.add_argument("csv", help="Input calibrator CSV with frequency and d_min columns")
+parser.add_argument("--out", default="dmin_summary.csv", help="Output summary CSV path")
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    df = pd.read_csv(args.csv)
+    summary, frac = summarize_dmin(df)
+    summary.to_csv(args.out, index=False)
+    if frac < 0.9:
+        raise SystemExit(f"d_min non-null fraction {frac:.3f} < 0.9")
+    if summary.empty or (summary["rho"] <= 0).any() or (summary["p"] >= 0.05).any():
+        raise SystemExit("Spearman correlation did not meet criteria")

--- a/tests/test_dmin_summary.py
+++ b/tests/test_dmin_summary.py
@@ -1,0 +1,35 @@
+import subprocess
+import sys
+import pandas as pd
+
+from assembly_diffusion.calibrators import summarize_dmin
+
+
+def _sample_df():
+    data = {
+        "id": list(range(10)),
+        "universe": ["S"] * 10,
+        "grammar": ["G"] * 10,
+        "As_lower": [0] * 10,
+        "As_upper": [1] * 10,
+        "validity": [1] * 10,
+        "d_min": list(range(1, 10)) + [None],
+        "frequency": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95],
+    }
+    return pd.DataFrame(data)
+
+
+def test_summarize_dmin(tmp_path):
+    df = _sample_df()
+    summary, frac = summarize_dmin(df)
+    assert frac == 0.9
+    assert summary.shape[0] == 1
+    assert summary.loc[0, "rho"] > 0
+    assert summary.loc[0, "p"] < 0.05
+
+    csv_path = tmp_path / "calibs.csv"
+    out_path = tmp_path / "summary.csv"
+    df.to_csv(csv_path, index=False)
+    subprocess.check_call([sys.executable, "scripts/summarize_dmin.py", str(csv_path), "--out", str(out_path)])
+    out_df = pd.read_csv(out_path)
+    assert "rho" in out_df.columns


### PR DESCRIPTION
## Summary
- add utility to summarize d_min estimates and Spearman correlations by assembly size
- expose CLI script to output summary CSV and enforce coverage and correlation thresholds
- test summarization and script execution

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689a73ae02bc8322a411e44decae705d