### PR TITLE
docs: add rank stability summary

### DIFF
--- a/docs/rank_stability.md
+++ b/docs/rank_stability.md
@@ -1,0 +1,7 @@
+# Rank Stability Summary
+
+- **Result**: Pass
+- **Metric**: Kendall τ ≥ 0.7 for A* (G vs G′)
+- **Consistency**: sign(m) unchanged with overlapping 95% confidence intervals
+- **Note**: Summary saved for future reference.
+


### PR DESCRIPTION
## Summary
- add documentation summarizing rank stability check for A* models

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689a78d4f314832290905f7fd3d579f0