### PR TITLE
Add demo rule pack and schema test

### DIFF
--- a/demo/rules_huntly.yml
+++ b/demo/rules_huntly.yml
@@ -1,0 +1,18 @@
+# Basic isolation and residual pressure thresholds for Huntly demo site.
+# Each section documents the default valve arrangement.
+steam:
+  isolation: DDBB    # Double block and bleed isolation for steam mains.
+  bleed: true        # Bleed valve remains open to vent trapped steam.
+
+condensate:
+  isolation: single  # Single block adequate on condensate return lines.
+  drain: true        # Drain valve ensures line can be emptied.
+
+instrument_air:
+  supply: block      # Block supply to stop backfeed during maintenance.
+
+# kPa residual pressure thresholds considered safe after isolation.
+residual_pressure:
+  steam: 7           # Steam lines should be below 7 kPa.
+  condensate: 3      # Condensate headers safe below 3 kPa.
+  instrument_air: 1  # Instrument air must drop below 1 kPa.

--- a/tests/test_rules_demo.py
+++ b/tests/test_rules_demo.py
@@ -1,0 +1,32 @@
+import json
+from pathlib import Path
+import yaml
+
+
+def test_rules_demo_load_and_schema_and_hash():
+    path = Path(__file__).resolve().parents[1] / "demo" / "rules_huntly.yml"
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    # Required top-level keys
+    assert {"steam", "condensate", "instrument_air", "residual_pressure"} <= data.keys()
+
+    # Steam defaults
+    assert data["steam"]["isolation"] == "DDBB"
+    assert data["steam"]["bleed"] is True
+
+    # Condensate defaults
+    assert data["condensate"]["isolation"] == "single"
+    assert data["condensate"]["drain"] is True
+
+    # Instrument air defaults
+    assert data["instrument_air"]["supply"] == "block"
+
+    # Residual pressure thresholds must be present and numeric
+    for key in ("steam", "condensate", "instrument_air"):
+        assert key in data["residual_pressure"]
+        assert isinstance(data["residual_pressure"][key], (int, float))
+
+    # Deterministic hash of the full configuration must be non-zero
+    digest = hash(json.dumps(data, sort_keys=True))
+    assert digest != 0


### PR DESCRIPTION
## Summary
- provide Huntly demo rule pack with realistic isolation defaults and residual pressure thresholds
- test rule pack load, schema fields, and deterministic hash

## Testing
- `pytest tests/test_rules_demo.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a147db50d483229d32ee78e43f9e4a