### PR TITLE
Add demo CSV fixtures and integrity tests

### DIFF
--- a/demo/air_map.csv
+++ b/demo/air_map.csv
@@ -1,0 +1,2 @@
+valve_tag,air_line_tag,air_source_tag
+VLV-102,IA-001,AC-101

--- a/demo/assets.csv
+++ b/demo/assets.csv
@@ -1,0 +1,6 @@
+tag,type,description
+B-101,Boiler,Package boiler supplying steam
+HX-100,HeatExchanger,Target heat exchanger
+CT-101,Tank,Condensate collection tank
+PT-101,PressureTransmitter,Steam pressure transmitter near HX-100
+AC-101,AirCompressor,Instrument air source

--- a/demo/drains_vents.csv
+++ b/demo/drains_vents.csv
@@ -1,0 +1,3 @@
+tag,line_tag,dv_type
+DV-100,ST-001,drain
+DV-101,CD-001,vent

--- a/demo/energy_sources.csv
+++ b/demo/energy_sources.csv
@@ -1,0 +1,5 @@
+asset_tag,line_tag
+B-101,ST-001
+B-101,ST-001-BP
+B-101,ST-001-PT
+AC-101,IA-001

--- a/demo/line_list.csv
+++ b/demo/line_list.csv
@@ -1,0 +1,6 @@
+tag,from_tag,to_tag,service,direction,description
+ST-001,B-101,HX-100,Steam,supply,Steam supply to HX-100
+ST-001-BP,B-101,HX-100,Steam,supply,Bypass around HX-100
+ST-001-PT,HX-100,PT-101,Steam,supply,Connection to pressure transmitter
+CD-001,HX-100,CT-101,Condensate,return,Condensate return to tank
+IA-001,AC-101,HX-100,InstrumentAir,supply,Instrument air to valves

--- a/demo/valves.csv
+++ b/demo/valves.csv
@@ -1,0 +1,4 @@
+tag,line_tag,type,bypass_group
+VLV-100,ST-001,block,BG-1
+VLV-101,ST-001-BP,block,BG-1
+VLV-102,ST-001-BP,control,BG-1

--- a/tests/test_demo_csvs.py
+++ b/tests/test_demo_csvs.py
@@ -1,0 +1,85 @@
+import pandas as pd
+from pathlib import Path
+
+BASE = Path(__file__).resolve().parents[1] / "demo"
+
+
+def _read(name: str) -> pd.DataFrame:
+    return pd.read_csv(BASE / name)
+
+
+def test_schema_and_uniqueness():
+    specs = {
+        "assets.csv": ["tag", "type", "description"],
+        "line_list.csv": [
+            "tag",
+            "from_tag",
+            "to_tag",
+            "service",
+            "direction",
+            "description",
+        ],
+        "valves.csv": ["tag", "line_tag", "type", "bypass_group"],
+        "drains_vents.csv": ["tag", "line_tag", "dv_type"],
+        "energy_sources.csv": ["asset_tag", "line_tag"],
+        "air_map.csv": ["valve_tag", "air_line_tag", "air_source_tag"],
+    }
+    for fname, cols in specs.items():
+        df = _read(fname)
+        assert list(df.columns) == cols
+        if "tag" in df.columns:
+            assert df["tag"].is_unique
+    lines = _read("line_list.csv")
+    assert lines["direction"].notna().all()
+    assert (lines["direction"].str.len() > 0).all()
+
+
+def test_cross_file_references():
+    assets = _read("assets.csv")
+    lines = _read("line_list.csv")
+    valves = _read("valves.csv")
+    drains = _read("drains_vents.csv")
+    energy = _read("energy_sources.csv")
+    air = _read("air_map.csv")
+
+    asset_tags = set(assets["tag"])
+    line_tags = set(lines["tag"])
+    valve_tags = set(valves["tag"])
+
+    assert set(lines["from_tag"]).issubset(asset_tags)
+    assert set(lines["to_tag"]).issubset(asset_tags)
+
+    assert set(valves["line_tag"]).issubset(line_tags)
+    assert set(drains["line_tag"]).issubset(line_tags)
+
+    assert set(energy["asset_tag"]).issubset(asset_tags)
+    assert set(energy["line_tag"]).issubset(line_tags)
+
+    assert set(air["valve_tag"]).issubset(valve_tags)
+    assert set(air["air_line_tag"]).issubset(line_tags)
+    assert set(air["air_source_tag"]).issubset(asset_tags)
+
+    for tag, service in lines[["tag", "service"]].itertuples(index=False):
+        if service in {"Steam", "InstrumentAir"}:
+            assert tag in set(energy["line_tag"])
+
+
+def test_mini_plant_content():
+    assets = _read("assets.csv")
+    lines = _read("line_list.csv")
+    valves = _read("valves.csv")
+
+    assert {"Steam", "Condensate", "InstrumentAir"}.issubset(set(lines["service"]))
+
+    groups = valves["bypass_group"].value_counts()
+    assert (groups.get("BG-1", 0)) >= 2
+
+    pt_rows = assets[assets["type"] == "PressureTransmitter"]
+    assert len(pt_rows) == 1
+    pt_tag = pt_rows.iloc[0]["tag"]
+    target_tag = "HX-100"
+    connected = (
+        ((lines["from_tag"] == pt_tag) & (lines["to_tag"] == target_tag))
+        | ((lines["to_tag"] == pt_tag) & (lines["from_tag"] == target_tag))
+    )
+    assert lines[connected & (lines["service"] == "Steam")].shape[0] == 1


### PR DESCRIPTION
## Summary
- add demo CSV data describing a small plant with steam, condensate, and instrument air
- include valves, drains/vents, energy sources, and air mapping with a bypass group and pressure transmitter
- add tests verifying schema, uniqueness, and cross-file referential integrity

## Testing
- `pytest tests/test_demo_csvs.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a147e81a50832286984812e4dda46f