### PR TITLE
Add graph builder from CSVs with validation

### DIFF
--- a/loto/graph_builder.py
+++ b/loto/graph_builder.py
@@ -1,0 +1,111 @@
+"""Utilities to construct NetworkX graphs from CSV inputs."""
+from __future__ import annotations
+
+from collections import defaultdict
+import csv
+from pathlib import Path
+from typing import Dict, Iterable, Mapping
+
+import networkx as nx
+
+__all__ = ["from_csvs"]
+
+
+def _trim_mapping(row: Mapping[str, str]) -> Dict[str, str]:
+    """Return a new dict with whitespace trimmed from string values."""
+    out: Dict[str, str] = {}
+    for key, value in row.items():
+        if isinstance(value, str):
+            out[key] = value.strip()
+        else:
+            out[key] = value
+    return out
+
+
+_TRUTHY = {"true", "t", "1", "yes", "y"}
+_FALSY = {"false", "f", "0", "no", "n", ""}
+
+
+def _to_bool(value: str) -> bool:
+    """Convert a CSV field to boolean in a case-insensitive manner."""
+    val = (value or "").strip().lower()
+    if val in _TRUTHY:
+        return True
+    if val in _FALSY:
+        return False
+    raise ValueError(f"Cannot interpret boolean value: {value!r}")
+
+
+def from_csvs(nodes_csv: Path, edges_csv: Path) -> Dict[str, nx.MultiDiGraph]:
+    """Build graphs grouped by domain from node and edge CSV files.
+
+    Parameters
+    ----------
+    nodes_csv:
+        Path to a CSV file describing nodes. Required columns: ``tag``,
+        ``type``, ``domain``, ``fail_state`` and ``health_score``.
+    edges_csv:
+        Path to a CSV file describing edges. Required columns: ``from_tag``,
+        ``to_tag``, ``domain`` and edge attributes ``is_isolation_point``,
+        ``iso_tag``, ``direction``, ``size_mm`` and ``bypass_group``.
+
+    Returns
+    -------
+    Dict[str, nx.MultiDiGraph]
+        Mapping of domain name to constructed graph.
+    """
+
+    graphs: Dict[str, nx.MultiDiGraph] = defaultdict(nx.MultiDiGraph)
+
+    # --- Load nodes ---
+    node_rows = []
+    with open(Path(nodes_csv), newline="") as fh:
+        reader = csv.DictReader(fh)
+        for raw_row in reader:
+            row = _trim_mapping(raw_row)
+            node_rows.append(row)
+
+    tags = [r["tag"] for r in node_rows]
+    if len(tags) != len(set(tags)):
+        raise ValueError("Duplicate node tags encountered")
+
+    node_rows.sort(key=lambda r: (r.get("domain", ""), r["tag"]))
+
+    for row in node_rows:
+        domain = row.get("domain", "")
+        g = graphs[domain]
+        attrs = {
+            "type": row.get("type"),
+            "domain": domain,
+            "tag": row.get("tag"),
+            "fail_state": row.get("fail_state"),
+            "health_score": float(row["health_score"]) if row.get("health_score") else None,
+        }
+        g.add_node(row["tag"], **attrs)
+
+    # --- Load edges ---
+    edge_rows = []
+    with open(Path(edges_csv), newline="") as fh:
+        reader = csv.DictReader(fh)
+        for raw_row in reader:
+            row = _trim_mapping(raw_row)
+            edge_rows.append(row)
+
+    edge_rows.sort(
+        key=lambda r: (r.get("domain", ""), r.get("from_tag", ""), r.get("to_tag", ""), r.get("iso_tag", ""))
+    )
+
+    for row in edge_rows:
+        domain = row.get("domain", "")
+        g = graphs[domain]
+        is_iso = _to_bool(row.get("is_isolation_point", "false"))
+        attrs = {
+            "is_isolation_point": is_iso,
+            "iso_tag": row.get("iso_tag"),
+            "direction": row.get("direction"),
+            "size_mm": float(row["size_mm"]) if row.get("size_mm") else None,
+            "bypass_group": row.get("bypass_group"),
+        }
+        g.add_edge(row.get("from_tag"), row.get("to_tag"), **attrs)
+
+    return dict(graphs)

--- a/tests/test_graph_from_csvs.py
+++ b/tests/test_graph_from_csvs.py
@@ -1,0 +1,142 @@
+import csv
+from pathlib import Path
+
+import pytest
+
+from loto.graph_builder import from_csvs
+
+
+@pytest.fixture
+def sample_csvs(tmp_path: Path):
+    nodes_path = tmp_path / "nodes.csv"
+    edges_path = tmp_path / "edges.csv"
+
+    # deliberately unsorted and with whitespace
+    node_rows = [
+        {"tag": "B ", "type": "Asset", "domain": "steam", "fail_state": "closed", "health_score": "0.8"},
+        {"tag": " A", "type": "Asset", "domain": "steam", "fail_state": "open", "health_score": "0.9"},
+        {"tag": "C", "type": "Asset", "domain": "air", "fail_state": "open", "health_score": "0.95"},
+        {"tag": "D", "type": "Asset", "domain": "air", "fail_state": "open", "health_score": "0.7"},
+    ]
+    edge_rows = [
+        {
+            "from_tag": "C",
+            "to_tag": " D",
+            "domain": "air",
+            "is_isolation_point": "false",
+            "iso_tag": "ISO2 ",
+            "direction": "return",
+            "size_mm": "50",
+            "bypass_group": "",
+        },
+        {
+            "from_tag": " A",
+            "to_tag": " B ",
+            "domain": "steam",
+            "is_isolation_point": "TRUE",
+            "iso_tag": " ISO1",
+            "direction": "supply",
+            "size_mm": "100",
+            "bypass_group": "BG1",
+        },
+    ]
+
+    with nodes_path.open("w", newline="") as fh:
+        writer = csv.DictWriter(
+            fh, fieldnames=["tag", "type", "domain", "fail_state", "health_score"]
+        )
+        writer.writeheader()
+        writer.writerows(node_rows)
+
+    with edges_path.open("w", newline="") as fh:
+        writer = csv.DictWriter(
+            fh,
+            fieldnames=[
+                "from_tag",
+                "to_tag",
+                "domain",
+                "is_isolation_point",
+                "iso_tag",
+                "direction",
+                "size_mm",
+                "bypass_group",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(edge_rows)
+
+    return nodes_path, edges_path
+
+
+def test_build_graphs(sample_csvs):
+    nodes_csv, edges_csv = sample_csvs
+    graphs = from_csvs(nodes_csv, edges_csv)
+
+    assert set(graphs.keys()) == {"steam", "air"}
+
+    steam = graphs["steam"]
+    air = graphs["air"]
+
+    assert list(steam.nodes) == ["A", "B"]  # deterministic order
+    assert list(air.nodes) == ["C", "D"]
+
+    attrs_a = steam.nodes["A"]
+    assert attrs_a["type"] == "Asset"
+    assert attrs_a["domain"] == "steam"
+    assert attrs_a["fail_state"] == "open"
+    assert attrs_a["health_score"] == pytest.approx(0.9)
+
+    edge_data = list(steam.edges(data=True))
+    assert edge_data == [
+        (
+            "A",
+            "B",
+            {
+                "is_isolation_point": True,
+                "iso_tag": "ISO1",
+                "direction": "supply",
+                "size_mm": 100.0,
+                "bypass_group": "BG1",
+            },
+        )
+    ]
+
+    air_edge = list(air.edges(data=True))[0][2]
+    assert air_edge["is_isolation_point"] is False
+    assert air_edge["iso_tag"] == "ISO2"
+
+
+def test_duplicate_tags(tmp_path: Path):
+    nodes_csv = tmp_path / "nodes.csv"
+    edges_csv = tmp_path / "edges.csv"
+
+    with nodes_csv.open("w", newline="") as fh:
+        writer = csv.DictWriter(
+            fh, fieldnames=["tag", "type", "domain", "fail_state", "health_score"]
+        )
+        writer.writeheader()
+        writer.writerow(
+            {"tag": "N1", "type": "Asset", "domain": "steam", "fail_state": "open", "health_score": "1"}
+        )
+        writer.writerow(
+            {"tag": "N1", "type": "Asset", "domain": "steam", "fail_state": "open", "health_score": "1"}
+        )
+
+    with edges_csv.open("w", newline="") as fh:
+        writer = csv.DictWriter(
+            fh,
+            fieldnames=[
+                "from_tag",
+                "to_tag",
+                "domain",
+                "is_isolation_point",
+                "iso_tag",
+                "direction",
+                "size_mm",
+                "bypass_group",
+            ],
+        )
+        writer.writeheader()
+
+    with pytest.raises(ValueError):
+        from_csvs(nodes_csv, edges_csv)


### PR DESCRIPTION
## Summary
- build domain-specific NetworkX graphs from node/edge CSV files
- trim whitespace, normalize boolean fields, and reject duplicate node tags
- test graph construction, attribute handling, determinism and duplicate tag errors

## Testing
- `pytest tests/test_graph_from_csvs.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a14bef44b48322b7605e7b4a07f2a3