### PR TITLE
Add immutable scheduling models with validation and topological sort

### DIFF
--- a/loto/scheduling/schedule_model.py
+++ b/loto/scheduling/schedule_model.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Tuple
+from collections import defaultdict
+import heapq
+
+
+@dataclass(frozen=True)
+class SchedTask:
+    """A single scheduled task with optional dependencies and resources."""
+
+    id: str
+    resources: Tuple[str, ...] = ()
+    predecessors: Tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class Resource:
+    """A consumable resource with positive capacity."""
+
+    id: str
+    capacity: int
+
+    def __post_init__(self) -> None:
+        if self.capacity <= 0:
+            raise ValueError("Resource capacity must be > 0")
+
+
+@dataclass(frozen=True)
+class Calendar:
+    """Working time definition with timezone information."""
+
+    tz: str
+    work_intervals: Tuple[Tuple[str, str], ...]
+
+
+@dataclass(frozen=True)
+class SchedGraph:
+    """Collection of tasks and resources with validation utilities."""
+
+    tasks: Dict[str, SchedTask]
+    resources: Dict[str, Resource]
+    calendar: Calendar | None = None
+
+    def validate(self) -> None:
+        """Validate structural consistency of the scheduling graph."""
+
+        # Check predecessor and resource references
+        for task in self.tasks.values():
+            for pred in task.predecessors:
+                if pred not in self.tasks:
+                    raise ValueError(f"Unknown predecessor '{pred}' for task '{task.id}'")
+            for rid in task.resources:
+                if rid not in self.resources:
+                    raise ValueError(f"Unknown resource '{rid}' for task '{task.id}'")
+
+        # Detect cycles via topological sort
+        try:
+            self.toposort()
+        except ValueError as exc:  # pragma: no cover - toposort handles message
+            raise ValueError("Cycle detected") from exc
+
+    def toposort(self) -> List[SchedTask]:
+        """Return tasks in a stable topological order."""
+
+        indeg = {tid: 0 for tid in self.tasks}
+        succ: Dict[str, List[str]] = defaultdict(list)
+
+        for task in self.tasks.values():
+            for pred in task.predecessors:
+                indeg[task.id] += 1
+                succ[pred].append(task.id)
+
+        for lst in succ.values():
+            lst.sort()
+
+        heap: List[str] = [tid for tid, d in indeg.items() if d == 0]
+        heapq.heapify(heap)
+
+        ordered: List[SchedTask] = []
+        indeg_local = indeg.copy()
+
+        while heap:
+            tid = heapq.heappop(heap)
+            ordered.append(self.tasks[tid])
+            for nxt in succ.get(tid, []):
+                indeg_local[nxt] -= 1
+                if indeg_local[nxt] == 0:
+                    heapq.heappush(heap, nxt)
+
+        if len(ordered) != len(self.tasks):
+            raise ValueError("Cycle detected")
+
+        return ordered
+
+
+__all__ = [
+    "SchedTask",
+    "Resource",
+    "Calendar",
+    "SchedGraph",
+]

--- a/tests/scheduling/test_schedule_model.py
+++ b/tests/scheduling/test_schedule_model.py
@@ -1,0 +1,46 @@
+import pytest
+
+from loto.scheduling.schedule_model import (
+    Calendar,
+    Resource,
+    SchedGraph,
+    SchedTask,
+)
+
+
+def _build_valid_graph() -> SchedGraph:
+    resources = {
+        "R1": Resource(id="R1", capacity=1),
+        "R2": Resource(id="R2", capacity=2),
+    }
+    tasks = {
+        "A": SchedTask(id="A", resources=("R1",), predecessors=()),
+        "B": SchedTask(id="B", resources=("R1",), predecessors=("A",)),
+        "C": SchedTask(id="C", resources=("R2",), predecessors=("A",)),
+        "D": SchedTask(id="D", resources=("R1", "R2"), predecessors=("B", "C")),
+    }
+    cal = Calendar(tz="UTC", work_intervals=(("09:00", "17:00"),))
+    return SchedGraph(tasks=tasks, resources=resources, calendar=cal)
+
+
+def test_valid_graph_passes() -> None:
+    graph = _build_valid_graph()
+    graph.validate()
+
+
+def test_toposort_respects_dependencies() -> None:
+    graph = _build_valid_graph()
+    order = [task.id for task in graph.toposort()]
+    assert order == ["A", "B", "C", "D"]
+
+
+def test_cycle_triggers_error() -> None:
+    resources = {"R1": Resource(id="R1", capacity=1)}
+    tasks = {
+        "A": SchedTask(id="A", resources=("R1",), predecessors=("C",)),
+        "B": SchedTask(id="B", resources=("R1",), predecessors=("A",)),
+        "C": SchedTask(id="C", resources=("R1",), predecessors=("B",)),
+    }
+    graph = SchedGraph(tasks=tasks, resources=resources)
+    with pytest.raises(ValueError, match="Cycle detected"):
+        graph.validate()


### PR DESCRIPTION
## Summary
- define immutable dataclasses for tasks, resources, calendars, and graphs
- add validation for dependencies, resources, and cycle detection
- provide stable topological sort for tasks
- test scheduling graph validation, cycle detection, and ordering

## Testing
- `python -m pytest tests/scheduling/test_schedule_model.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a14c1d994483228df8b42f00a81d17