### PR TITLE
Add duration samplers with context scaling and tests

### DIFF
--- a/loto/scheduling/duration_models.py
+++ b/loto/scheduling/duration_models.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Mapping
+import math
+import numpy as np
+
+
+@dataclass(frozen=True)
+class Triangular:
+    """Triangular distribution with parameters ``a`` ≤ ``m`` ≤ ``b``."""
+
+    a: float
+    m: float
+    b: float
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple validation
+        if not (self.a <= self.m <= self.b):
+            raise ValueError("Require a ≤ m ≤ b")
+
+    def scale(self, factor: float) -> "Triangular":
+        """Return a new distribution with scaled parameters."""
+        return Triangular(self.a * factor, self.m * factor, self.b * factor)
+
+    def __call__(self, rng: np.random.Generator) -> float:
+        """Sample a value in *seconds* using ``rng``."""
+        return float(rng.triangular(self.a, self.m, self.b))
+
+
+@dataclass(frozen=True)
+class Lognormal:
+    """Log-normal distribution parameterised by ``mu`` and ``sigma``."""
+
+    mu: float
+    sigma: float
+
+    def scale(self, factor: float) -> "Lognormal":
+        """Return a new distribution scaled by ``factor``."""
+        return Lognormal(self.mu + math.log(factor), self.sigma)
+
+    def __call__(self, rng: np.random.Generator) -> float:
+        """Sample a value in *seconds* using ``rng``."""
+        return float(rng.lognormal(self.mu, self.sigma))
+
+
+# Base sampler definitions used by :func:`make_sampler`.
+_BASE_SAMPLERS: Mapping[str, Callable[[], object]] = {
+    "triangular": lambda: Triangular(1.0, 2.0, 4.0),
+    "lognormal": lambda: Lognormal(0.0, 0.5),
+}
+
+
+def make_sampler(class_id: str, context: Mapping[str, float]) -> Callable[[np.random.Generator], float]:
+    """Factory returning a sampler adjusted for ``context``.
+
+    Parameters
+    ----------
+    class_id:
+        Identifier of the base sampler. Currently ``"triangular"`` and
+        ``"lognormal"`` are supported.
+    context:
+        Mapping providing ``health``, ``access`` and ``experience`` scores. Each
+        value should be positive; lower scores imply longer durations.
+    """
+
+    if class_id not in _BASE_SAMPLERS:
+        raise KeyError(f"Unknown sampler class_id '{class_id}'")
+
+    h = context.get("health", 1.0)
+    a = context.get("access", 1.0)
+    e = context.get("experience", 1.0)
+    if h <= 0 or a <= 0 or e <= 0:  # pragma: no cover - basic validation
+        raise ValueError("Context scores must be positive")
+
+    scale = 1.0 / (h * a * e)
+
+    base = _BASE_SAMPLERS[class_id]()
+    scaled = base.scale(scale)
+    return scaled
+
+
+__all__ = ["Triangular", "Lognormal", "make_sampler"]

--- a/tests/scheduling/test_duration_models.py
+++ b/tests/scheduling/test_duration_models.py
@@ -1,0 +1,56 @@
+import math
+import numpy as np
+from loto.scheduling.duration_models import Triangular, Lognormal, make_sampler
+
+N = 50_000
+
+
+def _check_stats(samples: np.ndarray, mean: float, std: float) -> None:
+    assert abs(samples.mean() - mean) / mean < 0.02
+    assert abs(samples.std(ddof=0) - std) / std < 0.05
+
+
+def test_triangular_stats() -> None:
+    rng = np.random.default_rng(0)
+    dist = Triangular(1.0, 2.0, 4.0)
+    samples = np.array([dist(rng) for _ in range(N)])
+    mean = (1 + 2 + 4) / 3
+    var = (1**2 + 2**2 + 4**2 - 1*2 - 1*4 - 2*4) / 18
+    _check_stats(samples, mean, math.sqrt(var))
+    rng1 = np.random.default_rng(123)
+    rng2 = np.random.default_rng(123)
+    assert [dist(rng1) for _ in range(5)] == [dist(rng2) for _ in range(5)]
+
+
+def test_lognormal_stats() -> None:
+    rng = np.random.default_rng(0)
+    dist = Lognormal(0.0, 0.5)
+    samples = np.array([dist(rng) for _ in range(N)])
+    mean = math.exp(0.5**2 / 2)
+    std = math.sqrt((math.exp(0.5**2) - 1) * math.exp(0.5**2))
+    _check_stats(samples, mean, std)
+    rng1 = np.random.default_rng(321)
+    rng2 = np.random.default_rng(321)
+    assert [dist(rng1) for _ in range(5)] == [dist(rng2) for _ in range(5)]
+
+
+def test_factory_scaling() -> None:
+    context = {"health": 0.5, "access": 1.0, "experience": 1.0}
+    sampler = make_sampler("triangular", context)
+    rng = np.random.default_rng(0)
+    samples = np.array([sampler(rng) for _ in range(N)])
+    base_mean = (1 + 2 + 4) / 3
+    base_std = math.sqrt((1**2 + 2**2 + 4**2 - 1*2 - 1*4 - 2*4) / 18)
+    scale = 1 / (0.5 * 1.0 * 1.0)
+    _check_stats(samples, base_mean * scale, base_std * scale)
+
+
+def test_factory_scaling_lognormal() -> None:
+    context = {"health": 1.0, "access": 0.5, "experience": 0.5}
+    sampler = make_sampler("lognormal", context)
+    rng = np.random.default_rng(0)
+    samples = np.array([sampler(rng) for _ in range(N)])
+    base_mean = math.exp(0.5**2 / 2)
+    base_std = math.sqrt((math.exp(0.5**2) - 1) * math.exp(0.5**2))
+    scale = 1 / (1.0 * 0.5 * 0.5)
+    _check_stats(samples, base_mean * scale, base_std * scale)


### PR DESCRIPTION
## Summary
- implement Triangular and Lognormal duration samplers returning seconds
- add `make_sampler` factory that scales base distributions by health/access/experience
- cover samplers with statistical and reproducibility tests

## Testing
- `pytest tests/scheduling/test_duration_models.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a18868517c8322bced5b86b17b99a5