### PR TITLE
Add isolation planner for steam DDBB with drain and verification

### DIFF
--- a/loto/isolation_planner.py
+++ b/loto/isolation_planner.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+"""Simple isolation planner for block and bleed selection.
+
+This module implements a very small subset of the functionality required to
+select isolation points for a given asset within a process graph.  It is not a
+full featured planner; it only supports the pieces needed by the accompanying
+tests.  The planner searches the graph for the nearest block valves, bleed
+valves, drains and verification instrumentation (PT/TT) using hop count as the
+primary metric and ``health_score`` as a tie breaker.
+"""
+
+from dataclasses import dataclass
+from typing import List, Sequence
+
+import networkx as nx
+
+__all__ = ["IsolationPlan", "plan_isolation"]
+
+
+@dataclass
+class IsolationPlan:
+    """Container for the isolation points returned by :func:`plan_isolation`."""
+
+    blocks: List[str]
+    bleed: str
+    drain: str
+    verify: str
+
+
+def _choose(
+    g: nx.MultiDiGraph,
+    distances: dict[str, int],
+    types: Sequence[str],
+    count: int,
+) -> List[str]:
+    """Return ``count`` nodes of ``types`` sorted by distance then health.
+
+    Parameters
+    ----------
+    g:
+        Graph to inspect.
+    distances:
+        Mapping of node id to hop count from the asset.
+    types:
+        Acceptable node ``type`` values.
+    count:
+        Number of nodes to return.
+    """
+
+    candidates: List[tuple[int, float, str]] = []
+    for node, attrs in g.nodes(data=True):
+        if attrs.get("type") in types and node in distances:
+            dist = distances[node]
+            health = attrs.get("health_score", 0.0) or 0.0
+            candidates.append((dist, -health, node))
+    candidates.sort()
+    return [n for _, _, n in candidates[:count]]
+
+
+def plan_isolation(g: nx.MultiDiGraph, asset: str) -> IsolationPlan:
+    """Plan isolation points for ``asset`` within ``g``.
+
+    The algorithm is extremely small in scope:
+
+    - two closest block valves
+    - one closest bleed valve
+    - nearest drain
+    - nearest PT/TT for verification
+
+    Nodes are compared first on hop count from ``asset`` and then by highest
+    ``health_score``.  The graph is treated as undirected for distance
+    calculations.
+    """
+
+    if asset not in g:
+        raise ValueError("unknown asset node")
+
+    undirected = g.to_undirected()
+    distances = nx.single_source_shortest_path_length(undirected, asset)
+
+    blocks = _choose(g, distances, ["block", "valve"], 2)
+    if len(blocks) != 2:
+        raise ValueError("expected at least two block valves")
+
+    bleeds = _choose(g, distances, ["bleed", "vent"], 1)
+    if not bleeds:
+        raise ValueError("expected a bleed valve")
+
+    drains = _choose(g, distances, ["drain"], 1)
+    if not drains:
+        raise ValueError("expected a drain")
+
+    verifies = _choose(g, distances, ["PT", "TT"], 1)
+    if not verifies:
+        raise ValueError("expected a PT or TT for verification")
+
+    return IsolationPlan(blocks=blocks, bleed=bleeds[0], drain=drains[0], verify=verifies[0])

--- a/tests/test_planner_ddbb.py
+++ b/tests/test_planner_ddbb.py
@@ -1,0 +1,49 @@
+import networkx as nx
+
+from loto import isolation_planner
+
+
+def _distance(g: nx.MultiDiGraph, src: str, dst: str) -> int:
+    return nx.shortest_path_length(g.to_undirected(), src, dst)
+
+
+def test_steam_ddbb_with_drain_and_verify():
+    g = nx.MultiDiGraph()
+    # asset node
+    g.add_node("A", type="asset", health_score=1.0)
+    # block valves
+    g.add_node("B1", type="block", health_score=0.5)
+    g.add_node("B2", type="block", health_score=0.9)
+    g.add_node("B3", type="block", health_score=0.7)
+    # bleeds
+    g.add_node("L1", type="bleed", health_score=0.6)
+    g.add_node("L2", type="bleed", health_score=0.8)
+    # drain and verification instrumentation
+    g.add_node("D1", type="drain", health_score=0.4)
+    g.add_node("PT1", type="PT", health_score=0.95)
+
+    # edges connecting the network
+    g.add_edge("A", "B1")
+    g.add_edge("B1", "B2")
+    g.add_edge("B1", "B3")
+    g.add_edge("A", "L1")
+    g.add_edge("A", "L2")
+    g.add_edge("A", "D1")
+    g.add_edge("A", "PT1")
+
+    plan = isolation_planner.plan_isolation(g, "A")
+
+    # Expect two blocks and a bleed
+    assert plan.blocks == ["B1", "B2"]
+    assert plan.bleed == "L2"  # L2 preferred over L1 due to higher health
+
+    # Drain and verification points present
+    assert plan.drain == "D1"
+    assert plan.verify == "PT1"
+
+    # Ensure the selected points are close to the asset
+    assert _distance(g, "A", plan.blocks[0]) == 1
+    assert _distance(g, "A", plan.blocks[1]) == 2
+    assert _distance(g, "A", plan.bleed) == 1
+    assert _distance(g, "A", plan.drain) == 1
+    assert _distance(g, "A", plan.verify) == 1


### PR DESCRIPTION
## Summary
- add `isolation_planner` that picks two block valves, a bleed, a drain and a PT/TT verify point based on hop count and health score
- cover planner with a placement test for the steam DDBB scenario

## Testing
- `pytest tests/test_planner_ddbb.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a18edfbabc8322b65fd0d395294e30