### PR TITLE
Improve bypass group handling with selection notes

### DIFF
--- a/tests/test_planner_bypass_heuristics.py
+++ b/tests/test_planner_bypass_heuristics.py
@@ -30,3 +30,7 @@ def test_bypass_and_lockable_preference():
     assert plan.bleed == "L2"
     assert plan.drain == "D1"
     assert plan.verify == "PT1"
+    # Notes document bypass handling and heuristic preferences
+    joined = " ".join(plan.notes)
+    assert "bypass group BG1" in joined
+    assert "lockable" in joined


### PR DESCRIPTION
## Summary
- Track reasoning for chosen isolation points by recording notes
- Include bypass group members encountered along selected paths
- Add test covering bypass-group inclusion and lockable preference notes

## Testing
- `pytest tests/test_planner_bypass_heuristics.py tests/test_planner_ddbb.py -q`

------
https://chatgpt.com/codex/tasks/task_b_68a19fc03a7c83229a641f61c2b6de1e