### PR TITLE
Add isolation plan application utilities

### DIFF
--- a/loto/sim_engine.py
+++ b/loto/sim_engine.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import networkx as nx
+
+from .isolation_planner import IsolationPlan
+
+__all__ = ["apply_plan"]
+
+
+def apply_plan(
+    graphs: Dict[str, nx.MultiDiGraph],
+    plan: IsolationPlan,
+) -> Dict[str, nx.MultiDiGraph]:
+    """Apply ``plan`` to ``graphs`` and return new per-domain graphs.
+
+    The function performs a purely functional transformation – ``graphs`` are
+    left unmodified.  Selected block valves are isolated by removing all edges
+    whose ``iso_tag`` matches the ``iso_tag`` of a block valve from the plan.
+    Drain and bleed nodes referenced by the plan are marked with
+    ``state='open'``.  All remaining topology is preserved.
+    """
+
+    # Clone graphs to avoid mutating the originals
+    cloned: Dict[str, nx.MultiDiGraph] = {
+        domain: g.copy() for domain, g in graphs.items()
+    }
+
+    # Determine iso_tag values for the block valves
+    block_iso_tags: set[str] = set()
+    for node in plan.blocks:
+        for g in cloned.values():
+            if node in g and g.nodes[node].get("iso_tag"):
+                block_iso_tags.add(g.nodes[node]["iso_tag"])
+
+    # Remove edges corresponding to selected blocks
+    for g in cloned.values():
+        to_remove = []
+        for u, v, key, data in g.edges(keys=True, data=True):
+            if data.get("iso_tag") in block_iso_tags:
+                to_remove.append((u, v, key))
+        if to_remove:
+            g.remove_edges_from(to_remove)
+
+        # Mark drain and bleed nodes open where present
+        for node in (plan.bleed, plan.drain):
+            if node in g:
+                g.nodes[node]["state"] = "open"
+
+    return cloned

--- a/tests/test_sim_apply.py
+++ b/tests/test_sim_apply.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import networkx as nx
+
+from loto.isolation_planner import IsolationPlan
+from loto import sim_engine
+
+
+def _build_graphs():
+    g = nx.MultiDiGraph()
+    # asset and other nodes
+    g.add_node("A", type="asset")
+    g.add_node("B1", type="block", iso_tag="B1")
+    g.add_node("B2", type="block", iso_tag="B2")
+    g.add_node("L1", type="bleed", iso_tag="L1")
+    g.add_node("D1", type="drain", iso_tag="D1")
+    g.add_node("C", type="pipe")
+
+    # block valve edges
+    g.add_edge("A", "B1", iso_tag="B1")
+    g.add_edge("B1", "A", iso_tag="B1")
+    g.add_edge("B1", "B2", iso_tag="B2")
+    g.add_edge("B2", "B1", iso_tag="B2")
+
+    # normal connection
+    g.add_edge("B2", "C")
+    g.add_edge("C", "B2")
+
+    # drain and bleed connections
+    g.add_edge("A", "L1", iso_tag="L1")
+    g.add_edge("A", "D1", iso_tag="D1")
+
+    other = nx.MultiDiGraph()
+    other.add_edge("X", "Y")
+
+    return {"steam": g, "cond": other}
+
+
+def test_apply_plan_removes_blocks_and_opens_drains():
+    graphs = _build_graphs()
+    plan = IsolationPlan(blocks=["B1", "B2"], bleed="L1", drain="D1", verify="PT1")
+
+    result = sim_engine.apply_plan(graphs, plan)
+
+    # original graphs untouched
+    assert graphs["steam"].number_of_edges() == 8
+    assert "state" not in graphs["steam"].nodes["L1"]
+    orig_iso = {d.get("iso_tag") for _, _, d in graphs["steam"].edges(data=True)}
+    assert "B1" in orig_iso and "B2" in orig_iso
+
+    # block edges removed in result
+    steam = result["steam"]
+    iso_tags = {data.get("iso_tag") for _, _, data in steam.edges(data=True)}
+    assert "B1" not in iso_tags and "B2" not in iso_tags
+
+    # drain and bleed marked open
+    assert steam.nodes["L1"]["state"] == "open"
+    assert steam.nodes["D1"]["state"] == "open"
+
+    # other domain preserved
+    assert list(result["cond"].edges()) == list(graphs["cond"].edges())


### PR DESCRIPTION
## Summary
- add `sim_engine.apply_plan` to clone graphs, remove selected block edges and mark drains/bleeds open
- cover edge removal and state changes with new `test_sim_apply`

## Testing
- `pytest tests/test_sim_apply.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68a1abbf010c8322ae37c230f339cba9