### PR TITLE
feat: add optional rework branching

### DIFF
--- a/loto/scheduling/rework.py
+++ b/loto/scheduling/rework.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import random
+from typing import Callable
+
+from .schedule_model import SchedGraph, SchedTask
+
+
+def maybe_rework(p: float, alt_task: SchedTask, rng: random.Random | None = None) -> Callable[[SchedGraph], SchedGraph]:
+    """Conditionally inject a rework task into a scheduling graph.
+
+    Parameters
+    ----------
+    p:
+        Probability of inserting ``alt_task``.  Must be in [0, 1].
+    alt_task:
+        Task template for the rework branch.  Its ``id`` will be made unique
+        before insertion, but its ``predecessors`` are preserved.
+    rng:
+        Optional random number generator.  Defaults to :mod:`random`'s module
+        level generator.
+
+    Returns
+    -------
+    Callable[[SchedGraph], SchedGraph]
+        Function that takes a :class:`~loto.scheduling.schedule_model.SchedGraph`
+        and returns a possibly augmented copy.
+    """
+
+    if not 0.0 <= p <= 1.0:
+        raise ValueError("p must be within [0, 1]")
+
+    rng = rng or random
+
+    def _inject(graph: SchedGraph) -> SchedGraph:
+        if rng.random() >= p:
+            return graph
+
+        # Copy tasks to avoid mutating the input graph
+        tasks = dict(graph.tasks)
+
+        base_id = alt_task.id
+        new_id = base_id
+        suffix = 1
+        while new_id in tasks:
+            new_id = f"{base_id}_{suffix}"
+            suffix += 1
+
+        tasks[new_id] = SchedTask(id=new_id,
+                                  resources=alt_task.resources,
+                                  predecessors=alt_task.predecessors)
+
+        new_graph = SchedGraph(tasks=tasks,
+                               resources=dict(graph.resources),
+                               calendar=graph.calendar)
+        # Ensure the resulting graph is structurally sound
+        new_graph.validate()
+        return new_graph
+
+    return _inject
+
+
+__all__ = ["maybe_rework"]

--- a/tests/scheduling/test_rework.py
+++ b/tests/scheduling/test_rework.py
@@ -1,0 +1,37 @@
+import random
+
+from loto.scheduling.schedule_model import SchedGraph, SchedTask
+from loto.scheduling.rework import maybe_rework
+
+
+def _base_graph() -> SchedGraph:
+    tasks = {
+        "A": SchedTask(id="A"),
+        "B": SchedTask(id="B", predecessors=("A",)),
+    }
+    return SchedGraph(tasks=tasks, resources={})
+
+
+def test_rework_occurs_when_p_one() -> None:
+    graph = _base_graph()
+    alt = SchedTask(id="B", predecessors=("B",))
+    transform = maybe_rework(1.0, alt, rng=random.Random(0))
+    new_graph = transform(graph)
+
+    assert new_graph is not graph
+    assert set(new_graph.tasks) == {"A", "B", "B_1"}
+    assert set(graph.tasks) == {"A", "B"}  # original unchanged
+
+    new_graph.validate()
+
+
+def test_rework_skipped_when_p_zero() -> None:
+    graph = _base_graph()
+    alt = SchedTask(id="B", predecessors=("B",))
+    transform = maybe_rework(0.0, alt, rng=random.Random(0))
+    same_graph = transform(graph)
+
+    assert same_graph is graph
+    assert set(graph.tasks) == {"A", "B"}
+
+    same_graph.validate()


### PR DESCRIPTION
## Summary
- add `maybe_rework` utility that conditionally injects a rework task with a unique id into a scheduling graph
- test rework branching occurs when p=1 and is skipped when p=0 while preserving graph validity

## Testing
- `pytest tests/scheduling/test_rework.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a1b0a528248322b59639417db1099b