### PR TITLE
Add pricing providers with CSV cache support

### DIFF
--- a/loto/pricing/__init__.py
+++ b/loto/pricing/__init__.py
@@ -1,0 +1,5 @@
+"""Pricing data providers."""
+
+from .providers import CsvProvider, StaticCurveProvider, Em6Provider
+
+__all__ = ["CsvProvider", "StaticCurveProvider", "Em6Provider"]

--- a/loto/pricing/providers.py
+++ b/loto/pricing/providers.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+
+
+class CsvProvider:
+    """Load pricing data from a CSV file.
+
+    The CSV file must contain ``time`` and ``price`` columns. ``time``
+    values are parsed as datetimes and normalised to 5‑minute buckets in
+    the ``Pacific/Auckland`` timezone.
+    """
+
+    def __init__(self, path: Path | str):
+        self.path = Path(path)
+        self._series: Optional[pd.Series] = None
+
+    def series(self) -> pd.Series:
+        if self._series is not None:
+            return self._series
+        if not self.path.exists():
+            raise FileNotFoundError(f"No such file: {self.path}")
+        df = pd.read_csv(self.path)
+        if "time" not in df.columns or "price" not in df.columns:
+            raise ValueError("CSV must contain 'time' and 'price' columns")
+        idx = pd.to_datetime(df["time"])
+        idx.name = None
+        tz = "Pacific/Auckland"
+        if idx.dt.tz is None:
+            idx = idx.dt.tz_localize(tz)
+        else:
+            idx = idx.dt.tz_convert(tz)
+        s = pd.Series(df["price"].values, index=idx, name="price").sort_index()
+        s = s.resample("5min").ffill()
+        self._series = s
+        return s
+
+
+class StaticCurveProvider:
+    """Return a pre-specified price curve."""
+
+    def __init__(self, curve: pd.Series):
+        if not isinstance(curve, pd.Series):
+            raise TypeError("curve must be a pandas Series")
+        self._curve = curve
+
+    def series(self) -> pd.Series:
+        return self._curve
+
+
+class Em6Provider:
+    """Stubbed Electricity Market (EM6) pricing provider.
+
+    Real EM6 access would require network calls. For testing purposes the
+    provider simply loads pricing data from a CSV cache. The cache
+    filename is derived from the supplied region or node.
+    """
+
+    def __init__(self, *, region: Optional[str] = None, node: Optional[str] = None, cache_dir: Path | str = "."):
+        if (region is None) == (node is None):
+            raise ValueError("Exactly one of region or node must be provided")
+        self.identifier = region or node
+        self.cache_dir = Path(cache_dir)
+        self._series: Optional[pd.Series] = None
+
+    def _cache_path(self) -> Path:
+        return self.cache_dir / f"{self.identifier}.csv"
+
+    def series(self) -> pd.Series:
+        if self._series is not None:
+            return self._series
+        path = self._cache_path()
+        if not path.exists():
+            raise FileNotFoundError(f"Cache file not found for '{self.identifier}': {path}")
+        self._series = CsvProvider(path).series()
+        return self._series

--- a/tests/pricing/test_providers.py
+++ b/tests/pricing/test_providers.py
@@ -1,0 +1,71 @@
+import pandas as pd
+import pytest
+
+from loto.pricing.providers import CsvProvider, StaticCurveProvider, Em6Provider
+
+
+def _sample_series():
+    return pd.Series(
+        [10.0, 20.0],
+        index=pd.date_range(
+            "2024-01-01", periods=2, freq="5min", tz="Pacific/Auckland"
+        ),
+        name="price",
+    )
+
+
+def _write_csv(path, series):
+    df = series.reset_index()
+    df.columns = ["time", "price"]
+    # write times without timezone information
+    df["time"] = df["time"].dt.tz_localize(None)
+    df.to_csv(path, index=False)
+
+
+def test_csv_provider_loads_series(tmp_path):
+    csv_path = tmp_path / "prices.csv"
+    _write_csv(csv_path, _sample_series())
+
+    provider = CsvProvider(csv_path)
+    result = provider.series()
+
+    expected = _sample_series()
+    pd.testing.assert_series_equal(result, expected)
+    assert result.index.freq == pd.tseries.frequencies.to_offset("5min")
+    assert str(result.index.tz) == "Pacific/Auckland"
+
+
+def test_csv_provider_missing_file(tmp_path):
+    provider = CsvProvider(tmp_path / "missing.csv")
+    with pytest.raises(FileNotFoundError):
+        provider.series()
+
+
+def test_static_curve_provider():
+    curve = _sample_series()
+    provider = StaticCurveProvider(curve)
+    pd.testing.assert_series_equal(provider.series(), curve)
+
+
+def test_em6_provider_uses_cache(tmp_path):
+    series = _sample_series()
+    cache_file = tmp_path / "north.csv"
+    _write_csv(cache_file, series)
+
+    provider = Em6Provider(region="north", cache_dir=tmp_path)
+    first = provider.series()
+    cache_file.unlink()  # remove file to ensure cached result is used
+    second = provider.series()
+
+    pd.testing.assert_series_equal(first, second)
+
+
+def test_em6_provider_bad_args(tmp_path):
+    with pytest.raises(ValueError):
+        Em6Provider()  # neither region nor node
+    with pytest.raises(ValueError):
+        Em6Provider(region="a", node="b")  # both provided
+
+    provider = Em6Provider(region="missing", cache_dir=tmp_path)
+    with pytest.raises(FileNotFoundError):
+        provider.series()


### PR DESCRIPTION
## Summary
- add `CsvProvider` to parse CSV price data into 5‑min Pacific/Auckland series
- add `StaticCurveProvider` for predetermined price curves
- add stub `Em6Provider` that loads from cached CSV files with in-memory caching
- cover providers with tests for timezone conversion, caching and error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a2768425288322820632f62799fe08