### PR TITLE
Implement price model and hedging blend utilities

### DIFF
--- a/loto/pricing/__init__.py
+++ b/loto/pricing/__init__.py
@@ -1,5 +1,14 @@
-"""Pricing data providers."""
+"""Pricing utilities and data providers."""
 
 from .providers import CsvProvider, StaticCurveProvider, Em6Provider
+from .model import PriceModel, PriceSeries
+from .hedge import hedge_price
 
-__all__ = ["CsvProvider", "StaticCurveProvider", "Em6Provider"]
+__all__ = [
+    "CsvProvider",
+    "StaticCurveProvider",
+    "Em6Provider",
+    "PriceModel",
+    "PriceSeries",
+    "hedge_price",
+]

--- a/loto/pricing/hedge.py
+++ b/loto/pricing/hedge.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from .model import PriceSeries
+
+
+def hedge_price(
+    spot: PriceSeries,
+    hedge: PriceSeries,
+    exposure: float,
+) -> PriceSeries:
+    """Blend ``spot`` with ``hedge`` using exposure ``alpha``.
+
+    The returned series is defined on the spot's buckets and is computed
+    as ``alpha * spot + (1 - alpha) * hedge`` where ``alpha`` is the
+    provided ``exposure``.
+    """
+
+    if not 0.0 <= exposure <= 1.0:
+        raise ValueError("exposure must be within [0, 1]")
+
+    hedge_aligned = hedge.interp(spot.buckets)
+    prices = tuple(
+        exposure * s + (1.0 - exposure) * h
+        for s, h in zip(spot.prices, hedge_aligned.prices)
+    )
+    return PriceSeries(spot.buckets, prices)
+
+
+__all__ = ["hedge_price"]

--- a/loto/pricing/model.py
+++ b/loto/pricing/model.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Sequence, Any
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class PriceSeries:
+    """Immutable price curve defined on integer buckets."""
+
+    buckets: tuple[float, ...]
+    prices: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        if len(self.buckets) != len(self.prices):
+            raise ValueError("buckets and prices must have the same length")
+
+    def interp(self, new_buckets: Sequence[float]) -> "PriceSeries":
+        """Linearly interpolate to ``new_buckets``."""
+
+        x = np.asarray(self.buckets, dtype=float)
+        y = np.asarray(self.prices, dtype=float)
+        nx = np.asarray(list(new_buckets), dtype=float)
+        ny = np.interp(nx, x, y)
+        return PriceSeries(tuple(nx.tolist()), tuple(ny.tolist()))
+
+
+def _normalise(value: Any, buckets: Sequence[float]) -> PriceSeries:
+    """Normalise ``value`` to a :class:`PriceSeries` on ``buckets``.
+
+    ``value`` may be a scalar, a sequence matching ``buckets``, a mapping
+    of bucket to price, or an existing :class:`PriceSeries` which will be
+    interpolated onto ``buckets``.
+    """
+
+    b = tuple(float(b) for b in buckets)
+
+    if isinstance(value, PriceSeries):
+        return value.interp(b)
+
+    if np.isscalar(value):  # type: ignore[arg-type]
+        return PriceSeries(b, tuple(float(value) for _ in b))
+
+    if isinstance(value, Mapping):
+        keys = sorted(float(k) for k in value.keys())
+        prices = [float(value[k]) for k in keys]
+        return PriceSeries(tuple(keys), tuple(prices)).interp(b)
+
+    if isinstance(value, Sequence):
+        if len(value) != len(buckets):
+            raise ValueError("Length of sequence must match buckets")
+        return PriceSeries(b, tuple(float(v) for v in value))
+
+    raise TypeError("Unsupported price input")
+
+
+@dataclass(frozen=True)
+class PriceModel:
+    """Container for low/medium/high price scenarios."""
+
+    low: PriceSeries
+    med: PriceSeries
+    high: PriceSeries
+
+    @classmethod
+    def build(
+        cls,
+        buckets: Sequence[float],
+        low: Any,
+        med: Any,
+        high: Any,
+    ) -> "PriceModel":
+        b = tuple(float(b) for b in buckets)
+        return cls(
+            low=_normalise(low, b),
+            med=_normalise(med, b),
+            high=_normalise(high, b),
+        )
+
+    def sample(
+        self,
+        scenario: str | None = None,
+        rng: np.random.Generator | None = None,
+    ) -> PriceSeries:
+        """Sample one of the scenarios.
+
+        If ``scenario`` is provided, it must be one of ``"low"``,
+        ``"med"`` or ``"high"``. Otherwise a scenario is chosen uniformly
+        at random.
+        """
+
+        if scenario is None:
+            rng = rng or np.random.default_rng()
+            scenario = rng.choice(["low", "med", "high"])  # type: ignore[assignment]
+        if scenario not in {"low", "med", "high"}:
+            raise ValueError("scenario must be 'low', 'med' or 'high'")
+        return getattr(self, scenario)
+
+
+__all__ = ["PriceSeries", "PriceModel"]

--- a/tests/pricing/test_model_hedge.py
+++ b/tests/pricing/test_model_hedge.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from loto.pricing.model import PriceModel, PriceSeries
+from loto.pricing.hedge import hedge_price
+
+
+def test_interpolation_to_schedule_buckets() -> None:
+    buckets = [0, 1, 2]
+    model = PriceModel.build(
+        buckets,
+        low=10.0,
+        med={0: 9.0, 2: 11.0},
+        high=[8.0, 9.0, 10.0],
+    )
+    series = model.sample("med")
+    assert series.buckets == (0.0, 1.0, 2.0)
+    assert series.prices == pytest.approx((9.0, 10.0, 11.0))
+
+
+def test_sampler_returns_known_scenario() -> None:
+    model = PriceModel.build([0, 1], low=1, med=2, high=3)
+    rng = np.random.default_rng(0)
+    s = model.sample(rng=rng)
+    assert s in [model.low, model.med, model.high]
+
+
+def test_hedged_price_blend() -> None:
+    spot = PriceSeries((0.0, 1.0, 2.0), (10.0, 20.0, 30.0))
+    hedge = PriceSeries((0.0, 2.0), (8.0, 14.0))
+    blended = hedge_price(spot, hedge, exposure=0.25)
+    expected = (
+        0.25 * 10.0 + 0.75 * 8.0,
+        0.25 * 20.0 + 0.75 * 11.0,
+        0.25 * 30.0 + 0.75 * 14.0,
+    )
+    assert blended.buckets == spot.buckets
+    assert blended.prices == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- normalize scalar, sequence, mapping, or series inputs into `PriceSeries`
- sample low/medium/high scenarios from `PriceModel`
- blend spot and hedge series using exposure alpha

## Testing
- `pytest tests/pricing/test_model_hedge.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a27afef944832298fd6f1f325fdce1